### PR TITLE
Create reporter for JUnit XML

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,4 @@ Thumbs.db
 build-plugin.gradle
 build-doc.txt
 .sonar
-build/
+/.nb-gradle/

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ Thumbs.db
 build-plugin.gradle
 build-doc.txt
 .sonar
+build/

--- a/README.adoc
+++ b/README.adoc
@@ -69,7 +69,11 @@ sourceDocuments:: (optional) an override to process several source files, which 
                       Defaults to all files in [x-]`${sourceDir}`.
 
 checkingResultsDir:: (optional) directory where the checking results written to.
-                      Defaults to `${sourceDir}/report/htmlchecks/`
+                      Defaults to `${buildDir}/report/htmlchecks/`
+
+junitResultsDir:: (optional) directory where the results written to in JUnit XML format. JUnit XML can be
+                  read by many tools including CI environments.
+				  Defaults to `${buildDir}/test-results/htmlchecks/`
 
 checkExternalLinks:: (optional, planned) if set to "true", external references are checked too.
                       Defaults to `false` (currently not implemented)

--- a/build.gradle
+++ b/build.gradle
@@ -72,14 +72,14 @@ dependencies {
 
 
     localGroovy()
-    testCompile("org.spockframework:spock-core:1.0-groovy-2.3")
+    testCompile("org.spockframework:spock-core:1.0-groovy-2.4")
             { exclude group: 'org.codehaus.groovy'}
 
     compile gradleApi()
     compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.3'
     compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.3'
 
-    testCompile 'junit:junit:4.11'
+    testCompile 'junit:junit:4.12'
 
     // jsoup is our awesome html parser, see jsoup.org
     compile group: 'org.jsoup', name: 'jsoup', version: '1.8.2'

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,7 +2,7 @@ HtmlSanityCheck - ChangeLog
 
 
 V.0.9.5
-
+April 8th 2016: Add JUnit XML reporting to support automated tools.
 
 V.0.9.3
 June 14th 2015: published on Gradle Plugin Repository

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.12-bin.zip

--- a/src/main/groovy/org/aim42/htmlsanitycheck/AllChecksRunner.groovy
+++ b/src/main/groovy/org/aim42/htmlsanitycheck/AllChecksRunner.groovy
@@ -40,12 +40,14 @@ class AllChecksRunner {
      *
      * @param filesToCheck all available checks are run against these files
      * @param checkingResultsDir where to put resulting test-report
+     * @param junitResultsDir where to put resulting JUnit XML
      * @param checkExternalResources if enabled, we also check remote links
      */
 
     public AllChecksRunner(
             Collection<File> filesToCheck,
             File checkingResultsDir,
+			File junitResultsDir,
             Boolean checkExternalResources
     ) {
         super()
@@ -53,6 +55,7 @@ class AllChecksRunner {
         runner = new ChecksRunner( AllCheckers.checkerClazzes,
                                     filesToCheck,
                                     checkingResultsDir,
+									junitResultsDir,
                                     checkExternalResources)
 
         logger.debug("AllChecksRunner created")
@@ -67,6 +70,7 @@ class AllChecksRunner {
     public AllChecksRunner(Collection<File> filesToCheck) {
         this( filesToCheck,
               File.createTempDir("temporary", "directory"),
+			  File.createTempDir("temporary", "junit"),
               false)
     }
 

--- a/src/main/groovy/org/aim42/htmlsanitycheck/ChecksRunner.groovy
+++ b/src/main/groovy/org/aim42/htmlsanitycheck/ChecksRunner.groovy
@@ -8,6 +8,7 @@ import org.aim42.htmlsanitycheck.collect.SinglePageResults
 import org.aim42.htmlsanitycheck.html.HtmlPage
 import org.aim42.htmlsanitycheck.report.ConsoleReporter
 import org.aim42.htmlsanitycheck.report.HtmlReporter
+import org.aim42.htmlsanitycheck.report.JUnitXmlReporter
 import org.aim42.htmlsanitycheck.report.Reporter
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -25,6 +26,8 @@ class ChecksRunner {
     // where do we put our results
     private File checkingResultsDir
 
+    // where do we put our junit results
+    private File junitResultsDir
 
     // TODO: handle checking of external resources
     private Boolean checkExternalResources = false
@@ -41,21 +44,23 @@ class ChecksRunner {
 
     // convenience constructors, mainly  for tests
     // ------------------------------------------------
-    public ChecksRunner(SortedSet<Class> checkerCollection,
+    public ChecksRunner(Set<Class> checkerCollection,
                         SortedSet<File> filesToCheck,
-                        File checkingResultsDir ) {
-        this( checkerCollection, filesToCheck, checkingResultsDir, false)
+                        File checkingResultsDir,
+						File junitResultsDir) {
+        this( checkerCollection, filesToCheck, checkingResultsDir, junitResultsDir, false)
     }
 
     // just ONE file to check and distinct directory
-    public ChecksRunner(SortedSet<Class> checkerCollection,
+    public ChecksRunner(Set<Class> checkerCollection,
                         File fileToCheck,
-                        File checkingResultsDir ) {
-        this( checkerCollection, [fileToCheck], checkingResultsDir, false)
+                        File checkingResultsDir,
+						File junitResultsDir) {
+        this( checkerCollection, [fileToCheck], checkingResultsDir, junitResultsDir, false)
     }
 
     // with just ONE file to check
-    public ChecksRunner(SortedSet<Class> checkerCollection,
+    public ChecksRunner(Set<Class> checkerCollection,
                         File fileToCheck ) {
         this( checkerCollection, [fileToCheck], fileToCheck.getParentFile(), false)
     }
@@ -63,8 +68,9 @@ class ChecksRunner {
     // with ONE checker and ONE file and target directory
     public ChecksRunner( Class checkerCollection,
                          File fileToCheck,
-                         File checkingResultsDir ) {
-        this( [checkerCollection], [fileToCheck], checkingResultsDir, false)
+                         File checkingResultsDir,
+						 File junitResultsDir) {
+        this( [checkerCollection], [fileToCheck], checkingResultsDir, junitResultsDir, false)
     }
 
     // with just ONE checker and ONE file...
@@ -85,12 +91,14 @@ class ChecksRunner {
             Set<Class> checkerCollection,
             Set<File> filesToCheck,
             File checkingResultsDir,
+			File junitResultsDir,
             Boolean checkExternalResources
     ) {
         this.resultsForAllPages = new PerRunResults()
 
         this.filesToCheck = filesToCheck
         this.checkingResultsDir = checkingResultsDir
+		this.junitResultsDir = junitResultsDir
 
         this.checkers = CheckerCreator.createCheckerClassesFrom( checkerCollection )
 
@@ -155,6 +163,9 @@ class ChecksRunner {
         // and then report the results
         reportCheckingResultsOnConsole()
         reportCheckingResultsAsHTML(checkingResultsDir.absolutePath)
+		if (junitResultsDir) {
+			reportCheckingResultsAsJUnitXml(junitResultsDir.absolutePath)			
+		}
     }
 
 
@@ -178,6 +189,14 @@ class ChecksRunner {
         reporter.reportFindings()
     }
 
+    /**
+     * report results in JUnit XML
+     */
+    private void reportCheckingResultsAsJUnitXml(String resultsDir) {
+
+        Reporter reporter = new JUnitXmlReporter(resultsForAllPages, resultsDir)
+        reporter.reportFindings()
+    }
 }
 
 /************************************************************************

--- a/src/main/groovy/org/aim42/htmlsanitycheck/HtmlSanityCheckTask.groovy
+++ b/src/main/groovy/org/aim42/htmlsanitycheck/HtmlSanityCheckTask.groovy
@@ -32,6 +32,11 @@ class HtmlSanityCheckTask extends DefaultTask {
     @OutputDirectory
     File checkingResultsDir
 
+    // where do we store junit results
+    @Optional
+    @OutputDirectory
+    File junitResultsDir
+
     // shall we also check external resources?
     @Optional
     Boolean checkExternalLinks = false
@@ -53,6 +58,7 @@ class HtmlSanityCheckTask extends DefaultTask {
 
         // give sensible default for output directory
         checkingResultsDir = new File(project.buildDir, '/report/htmlchecks/')
+		junitResultsDir = new File(project.buildDir, '/test-results/htmlchecks/')
 
         // we start with an empty Set
         allFilesToCheck = new HashSet<File>()
@@ -77,6 +83,11 @@ class HtmlSanityCheckTask extends DefaultTask {
             checkingResultsDir.mkdirs()
             assert checkingResultsDir.isDirectory()
             assert checkingResultsDir.canWrite()
+			if (junitResultsDir) {
+				junitResultsDir.mkdirs()
+				assert junitResultsDir.isDirectory()
+				assert junitResultsDir.canWrite()
+			}
 
             // TODO: unclear: do we need to adjust pathnames if running on Windows(tm)??
 
@@ -87,6 +98,7 @@ class HtmlSanityCheckTask extends DefaultTask {
             def allChecksRunner = new AllChecksRunner(
                     allFilesToCheck,
                     checkingResultsDir,
+					junitResultsDir,
                     checkExternalLinks
             )
 
@@ -156,6 +168,7 @@ class HtmlSanityCheckTask extends DefaultTask {
         logger.info "Files to check  : $sourceDocuments"
         logger.info "Source directory: $sourceDir"
         logger.info "Results dir     : $checkingResultsDir"
+        logger.info "JUnit dir       : $junitResultsDir"
         logger.info "Check externals : $checkExternalLinks"
 
     }

--- a/src/main/groovy/org/aim42/htmlsanitycheck/collect/Finding.groovy
+++ b/src/main/groovy/org/aim42/htmlsanitycheck/collect/Finding.groovy
@@ -79,7 +79,7 @@ class Finding {
         String refCount = (nrOfOccurrences > 1) ? " (reference count: $nrOfOccurrences)": ""
         String suggestionStr = (suggestions.size() > 0) ? " (Suggestions: " + suggestions.join(", ") + ")": ""
 
-        return item + refCount + "\n" + suggestionStr
+        return item + refCount + (suggestionStr ? "\n" + suggestionStr : "")
     }
 
 

--- a/src/main/groovy/org/aim42/htmlsanitycheck/report/JUnitXmlReporter.groovy
+++ b/src/main/groovy/org/aim42/htmlsanitycheck/report/JUnitXmlReporter.groovy
@@ -1,0 +1,100 @@
+package org.aim42.htmlsanitycheck.report
+
+import groovy.transform.InheritConstructors
+import groovy.xml.MarkupBuilder
+import org.aim42.htmlsanitycheck.collect.PerRunResults
+import org.aim42.htmlsanitycheck.collect.SingleCheckResults
+import org.aim42.htmlsanitycheck.collect.SinglePageResults
+
+/************************************************************************
+ * This is free software - without ANY guarantee!
+ *
+ *
+ * Copyright 2016, Patrick Double, https://github.com/double16
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *********************************************************************** */
+
+/**
+ * Write the findings report to JUnit XML. Allows tools processing JUnit to
+ * include the findings.
+ */
+@InheritConstructors
+class JUnitXmlReporter extends Reporter {
+	File outputPath
+
+	public JUnitXmlReporter( PerRunResults runResults, String outputPath) {
+        super( runResults )
+		this.outputPath = new File(outputPath)
+    }
+
+    @Override
+    void initReport() {
+		if (!outputPath.canWrite() && !outputPath.mkdirs()) {
+			throw new IOException("Cannot create or write to ${outputPath}")
+		}		
+    }
+
+    @Override
+    void reportOverallSummary() {
+    }
+
+    @Override
+    void reportPageSummary( SinglePageResults pageResult ) {
+		String name = pageResult.pageFilePath ?: pageResult.pageTitle ?: UUID.randomUUID()
+		String sanitiziedPath = name.replaceAll(~/[^A-Za-z0-9_-]+/, '_')
+		File testOutputFile = new File(outputPath, "TEST-${sanitiziedPath}.xml")
+		testOutputFile.withWriter { writer ->
+			def builder = new MarkupBuilder(writer)
+			builder.testsuite(
+				tests: pageResult.nrOfItemsCheckedOnPage(),
+				failures: pageResult.nrOfFindingsOnPage(), 
+				errors:0,
+				time:0,
+				name:name) {
+				pageResult.singleCheckResults?.each { singleCheckResult ->
+					testcase(
+						assertions:singleCheckResult.nrOfItemsChecked,
+						time:0,
+						name:(singleCheckResult.whatIsChecked ?: '')
+					) {
+						singleCheckResult.findings.each { finding ->
+							failure(
+								type:"${[singleCheckResult.sourceItemName, singleCheckResult.targetItemName].findAll().join(' -> ')}", 
+								message:finding.item, 
+								finding.suggestions?.join(", ") ?: '')
+						}
+					}
+				}
+			}
+		}
+    }
+
+    @Override
+    protected void reportPageFooter() {
+    }
+
+    @Override
+    protected void reportSingleCheckSummary( SingleCheckResults checkResults ) {
+    }
+
+    @Override
+    protected void reportSingleCheckDetails( SingleCheckResults checkResults  ) {
+    }
+
+    @Override
+    void closeReport() {
+    }
+
+}

--- a/src/main/groovy/org/aim42/htmlsanitycheck/report/JUnitXmlReporter.groovy
+++ b/src/main/groovy/org/aim42/htmlsanitycheck/report/JUnitXmlReporter.groovy
@@ -53,10 +53,11 @@ class JUnitXmlReporter extends Reporter {
     @Override
     void reportPageSummary( SinglePageResults pageResult ) {
 		String name = pageResult.pageFilePath ?: pageResult.pageTitle ?: UUID.randomUUID()
-		String sanitiziedPath = name.replaceAll(~/[^A-Za-z0-9_-]+/, '_')
-		File testOutputFile = new File(outputPath, "TEST-${sanitiziedPath}.xml")
+		String sanitizedPath = name.replaceAll(~/[^A-Za-z0-9_-]+/, '_')
+		File testOutputFile = new File(outputPath, "TEST-${sanitizedPath}.xml")
 		testOutputFile.withWriter { writer ->
 			def builder = new MarkupBuilder(writer)
+			builder.doubleQuotes = true
 			builder.testsuite(
 				tests: pageResult.nrOfItemsCheckedOnPage(),
 				failures: pageResult.nrOfFindingsOnPage(), 

--- a/src/main/groovy/org/aim42/htmlsanitycheck/report/JUnitXmlReporter.groovy
+++ b/src/main/groovy/org/aim42/htmlsanitycheck/report/JUnitXmlReporter.groovy
@@ -71,7 +71,7 @@ class JUnitXmlReporter extends Reporter {
 					) {
 						singleCheckResult.findings.each { finding ->
 							failure(
-								type:"${[singleCheckResult.sourceItemName, singleCheckResult.targetItemName].findAll().join(' -> ')}", 
+								type:"${[singleCheckResult.sourceItemName, singleCheckResult.targetItemName].findAll().join(' - ')}",
 								message:finding.item, 
 								finding.suggestions?.join(', ') ?: '')
 						}

--- a/src/main/groovy/org/aim42/htmlsanitycheck/report/JUnitXmlReporter.groovy
+++ b/src/main/groovy/org/aim42/htmlsanitycheck/report/JUnitXmlReporter.groovy
@@ -34,7 +34,7 @@ import org.aim42.htmlsanitycheck.collect.SinglePageResults
 class JUnitXmlReporter extends Reporter {
 	File outputPath
 
-	public JUnitXmlReporter( PerRunResults runResults, String outputPath) {
+	JUnitXmlReporter( PerRunResults runResults, String outputPath) {
         super( runResults )
 		this.outputPath = new File(outputPath)
     }
@@ -43,7 +43,7 @@ class JUnitXmlReporter extends Reporter {
     void initReport() {
 		if (!outputPath.canWrite() && !outputPath.mkdirs()) {
 			throw new IOException("Cannot create or write to ${outputPath}")
-		}		
+		}
     }
 
     @Override
@@ -73,7 +73,7 @@ class JUnitXmlReporter extends Reporter {
 							failure(
 								type:"${[singleCheckResult.sourceItemName, singleCheckResult.targetItemName].findAll().join(' -> ')}", 
 								message:finding.item, 
-								finding.suggestions?.join(", ") ?: '')
+								finding.suggestions?.join(', ') ?: '')
 						}
 					}
 				}

--- a/src/test/groovy/org/aim42/htmlsanitycheck/AllChecksRunnerTest.groovy
+++ b/src/test/groovy/org/aim42/htmlsanitycheck/AllChecksRunnerTest.groovy
@@ -63,9 +63,11 @@ class AllChecksRunnerTest extends GroovyTestCase {
         // create file
         tmpFile = File.createTempFile("testfile", ".html") << HTML
 
+        File testDir = File.createTempDir( "testdir", "")
         allChecksRunner = new AllChecksRunner(
                 new LinkedHashSet<File>( [tmpFile] ),
-                File.createTempDir( "testdir", ""),
+                testDir,
+				testDir,
                 false)
 
         SinglePageResults pageResults = allChecksRunner.performAllChecksForOneFile( tmpFile )

--- a/src/test/groovy/org/aim42/htmlsanitycheck/ChecksRunnerTest.groovy
+++ b/src/test/groovy/org/aim42/htmlsanitycheck/ChecksRunnerTest.groovy
@@ -1,5 +1,6 @@
 package org.aim42.htmlsanitycheck
 
+import org.aim42.htmlsanitycheck.check.AllCheckers
 import org.aim42.htmlsanitycheck.check.BrokenCrossReferencesChecker
 import org.aim42.htmlsanitycheck.collect.SinglePageResults
 import org.junit.Before
@@ -28,9 +29,10 @@ class ChecksRunnerTest extends GroovyTestCase {
 
         // wrap fileToTest in Collection to comply to AllChecksRunner API
         checksRunner = new ChecksRunner(
-                BrokenCrossReferencesChecker.class,
+                AllCheckers.checkerClazzes,
                 fileToTest,
-                fileToTest.getParentFile())
+                fileToTest.getParentFile(),
+				fileToTest.getParentFile())
 
         SinglePageResults pageResults = checksRunner.performChecksForOneFile(fileToTest)
 
@@ -39,7 +41,7 @@ class ChecksRunnerTest extends GroovyTestCase {
         // 0 items checked
         // 0 findings
         // title = "hsc"
-        int expected = 5
+        int expected = AllCheckers.checkerClazzes.size()
         assertEquals("expected $expected kinds of checks", expected, pageResults.singleCheckResults.size())
 
         assertEquals("expected 0 items checked", 0, pageResults.nrOfItemsCheckedOnPage())
@@ -65,13 +67,14 @@ class ChecksRunnerTest extends GroovyTestCase {
         fileToTest = File.createTempFile("testfile", ".html") << HTML
 
         checksRunner = new ChecksRunner(
-                BrokenCrossReferencesChecker.class,
+                AllCheckers.checkerClazzes,
                 fileToTest,
-                fileToTest.getParentFile())
+                fileToTest.getParentFile(),
+				fileToTest.getParentFile())
 
         SinglePageResults pageResults = checksRunner.performChecksForOneFile(fileToTest)
 
-        int expected = 5
+        int expected = AllCheckers.checkerClazzes.size()
         assertEquals("expected $expected kinds of checks", expected, pageResults.singleCheckResults.size())
 
         assertEquals("expected 2 findings", 2, pageResults.nrOfFindingsOnPage())

--- a/src/test/groovy/org/aim42/htmlsanitycheck/check/BrokenCrossReferencesCheckerTest.groovy
+++ b/src/test/groovy/org/aim42/htmlsanitycheck/check/BrokenCrossReferencesCheckerTest.groovy
@@ -67,7 +67,7 @@ class BrokenCrossReferencesCheckerTest extends GroovyTestCase {
         assertEquals( "expected four checks", 4, collector.nrOfItemsChecked)
 
         String actual = collector.findings.first()
-        String expected = "link target \"nonexisting\" missing"
+        String expected = "link target \"nonexisting\" missing\n (Suggestions: aim42)"
         String message = "expected $expected"
 
         assertEquals(message, expected, actual)

--- a/src/test/groovy/org/aim42/htmlsanitycheck/report/JUnitXmlReporterTest.groovy
+++ b/src/test/groovy/org/aim42/htmlsanitycheck/report/JUnitXmlReporterTest.groovy
@@ -1,0 +1,181 @@
+package org.aim42.htmlsanitycheck.report
+
+import org.aim42.htmlsanitycheck.collect.Finding
+import org.aim42.htmlsanitycheck.collect.PerRunResults
+import org.aim42.htmlsanitycheck.collect.SingleCheckResults
+import org.aim42.htmlsanitycheck.collect.SinglePageResults
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+// see end-of-file for license information
+
+
+class JUnitXmlReporterTest extends GroovyTestCase {
+
+    Finding singleFinding
+    SingleCheckResults singleCheckResults
+    SinglePageResults  singlePageResults
+    PerRunResults      runResults
+
+    JUnitXmlReporter reporter
+	File outputPath
+
+    String whatToExpect
+
+    @Before
+    public void setUp() {
+        singleCheckResults = new SingleCheckResults()
+
+        singleFinding = new Finding("")
+
+        singlePageResults = new SinglePageResults()
+
+        runResults = new PerRunResults()
+		
+		outputPath = File.createTempDir()
+        reporter = new JUnitXmlReporter( runResults, outputPath.absolutePath )
+    }
+
+	@After
+	public void tearDown() {
+		if (outputPath) {
+			outputPath.traverse {
+				System.err.println "${it}: ${it.text}"
+			}
+		}
+		outputPath?.deleteDir()
+	}
+	
+	private generateReportAndReturnTestsuiteNode() {
+		reporter.reportFindings()
+		new XmlSlurper().parse(new File(reporter.outputPath))
+	}
+
+    @Test
+    public void testEmptyReporter() {
+		reporter.reportFindings()
+		assertEquals("Empty reporter has no JUnit results", 0, outputPath.listFiles().length)
+    }
+
+
+    @Test
+    public void testZeroChecks() {
+        addSingleCheckResultsToReporter( singleCheckResults )
+
+		reporter.reportFindings()
+		def testsuite = new XmlSlurper().parse(outputPath.listFiles()[0])
+        assertEquals("Zero checks expected", "0", testsuite.@tests.text())
+        assertEquals("Zero findings expected", "0", testsuite.@failures.text())
+        assertEquals("Zero testcases expected", 1, testsuite.testcase.size())
+    }
+
+    @Test
+    public void testSingleFindingWithoutChecks() {
+        // now add one finding, but no check.. (nonsense, should never occur)
+        singleCheckResults.addFinding(singleFinding)
+        addSingleCheckResultsToReporter( singleCheckResults )
+
+		reporter.reportFindings()
+		def testsuite = new XmlSlurper().parse(outputPath.listFiles()[0])
+        assertEquals("expected no check", "0", testsuite.@tests.text())
+        assertEquals("expected one finding", "1", testsuite.@failures.text())
+        assertEquals("One testcase expected", 1, testsuite.testcase.size())
+        assertEquals("One testcase failures expected", 1, testsuite.testcase.failure.size())
+    }
+
+
+    @Test
+    public void testOneFindingOneCheck() {
+        singleCheckResults.addFinding(singleFinding)
+        singleCheckResults.incNrOfChecks()
+
+        addSingleCheckResultsToReporter( singleCheckResults )
+
+		reporter.reportFindings()
+		def testsuite = new XmlSlurper().parse(outputPath.listFiles()[0])
+        assertEquals("Expect one finding", "1", testsuite.@failures.text())
+        assertEquals("Expect one check", "1", testsuite.@tests.text())
+        assertEquals("One testcase expected", 1, testsuite.testcase.size())
+        assertEquals("One testcase failure expected", 1, testsuite.testcase.failure.size())
+    }
+
+    @Test
+    public void testOneFindingTenChecks() {
+        // one finding, ten checks.. 90% successful
+        singleCheckResults.addFinding(singleFinding)
+        singleCheckResults.nrOfItemsChecked = 10
+
+        addSingleCheckResultsToReporter( singleCheckResults )
+
+		reporter.reportFindings()
+		def testsuite = new XmlSlurper().parse(outputPath.listFiles()[0])
+        assertEquals("Expect one finding", "1", testsuite.@failures.text())
+        assertEquals("Expect ten checks", "10", testsuite.@tests.text())
+        assertEquals("Expect one testcase", 1, testsuite.testcase.size())
+        assertEquals("One testcase failure expected", 1, testsuite.testcase.failure.size())
+    }
+
+    @Test
+    public void testThreeFindingsTenChecks() {
+        // three findings, ten checks.. 70% successful
+        for (int i = 1; i<=3; i++) {
+            singleCheckResults.addFinding( new Finding("finding $i"))
+        }
+        singleCheckResults.nrOfItemsChecked = 10
+
+        addSingleCheckResultsToReporter( singleCheckResults )
+
+		reporter.reportFindings()
+		def testsuite = new XmlSlurper().parse(outputPath.listFiles()[0])
+        assertEquals("Expect three findings", "3", testsuite.@failures.text())
+        assertEquals("Expect ten checks", "10", testsuite.@tests.text())
+        assertEquals("Expect one testcases", 1, testsuite.testcase.size())
+        assertEquals("Expect three testcase failures", 3, testsuite.testcase.failure.size())
+    }
+
+
+    @Test
+    public void testOneFindingSixChecks() {
+        singleCheckResults.addFinding(singleFinding)
+        singleCheckResults.nrOfItemsChecked = 6
+
+        addSingleCheckResultsToReporter( singleCheckResults )
+
+		reporter.reportFindings()
+		def testsuite = new XmlSlurper().parse(outputPath.listFiles()[0])
+        assertEquals("Expect one finding", "1", testsuite.@failures.text())
+        assertEquals("Expect six checks", "6", testsuite.@tests.text())
+        assertEquals("Expect one testcases", 1, testsuite.testcase.size())
+        assertEquals("Expect six testcase failures", 1, testsuite.testcase.failure.size())
+    }
+
+    @Test
+    public void test99Findings200Checks() {
+        int nrOfChecks = 200
+        int nrOfFindings = 99
+
+        for (int i = 1; i <= nrOfFindings; i++) {
+            singleCheckResults.addFinding( new Finding( "finding $i"))
+        }
+        singleCheckResults.nrOfItemsChecked = nrOfChecks
+
+        addSingleCheckResultsToReporter( singleCheckResults )
+
+		reporter.reportFindings()
+		def testsuite = new XmlSlurper().parse(outputPath.listFiles()[0])
+        assertEquals("Expect $nrOfFindings findings", nrOfFindings as String, testsuite.@failures.text() )
+        assertEquals("Expect $nrOfChecks checks", nrOfChecks as String, testsuite.@tests.text() )
+        assertEquals("Expect one testcase", 1, testsuite.testcase.size())
+        assertEquals("Expect $nrOfChecks testcase failures", nrOfFindings, testsuite.testcase.failure.size())
+    }
+
+	
+    private void addSingleCheckResultsToReporter( SingleCheckResults scr ) {
+        SinglePageResults spr = new SinglePageResults()
+        spr.addResultsForSingleCheck( scr )
+        reporter.addCheckingResultsForOnePage( spr )
+    }
+}

--- a/src/test/groovy/org/aim42/htmlsanitycheck/report/JUnitXmlReporterTest.groovy
+++ b/src/test/groovy/org/aim42/htmlsanitycheck/report/JUnitXmlReporterTest.groovy
@@ -34,8 +34,8 @@ class JUnitXmlReporterTest extends GroovyTestCase {
         singlePageResults = new SinglePageResults()
 
         runResults = new PerRunResults()
-		
-		outputPath = File.createTempDir()
+
+        outputPath = File.createTempDir()
         reporter = new JUnitXmlReporter( runResults, outputPath.absolutePath )
     }
 


### PR DESCRIPTION
JUnit XML is recognized by many tools for test results. This change outputs findings in this format so that tools can pick them up. In particular, it will help CI environments.