### PR TITLE
Added "Similar Projects" section to README.adoc that points to the gradle-linkchecker-plugin.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -293,6 +293,10 @@ http://code4reference.com/2012/08/gradle-custom-plugin-part-1/[part 1] and
 http://code4reference.com/2012/08/gradle-custom-plugin-part-2/[part 2].
 * Of course, the http://jsoup.org/apidocs/[JSoup API documentation]
 
+== Similar Projects
+The https://github.com/rackerlabs/gradle-linkchecker-plugin[gradle-linkchecker-plugin] is an (open source) gradle plugin
+which validates that all links in a local HTML file tree go out to other existing local files or remote web locations.
+It creates a simple text file report and might be a complement to this `HtmlSanityChecker`.
 
 == Contributing
 Please report {plugin-issues}[issues or suggestions].


### PR DESCRIPTION
Updated `README.adoc` to point to [gradle-linkchecker-plugin](https://github.com/rackerlabs/gradle-linkchecker-plugin) following a [Twitter discussion](https://twitter.com/aalmiray/status/1020173446662311936) started by Eric Wendelin from Gradleware.