### PR TITLE
added asciidoc-diagram to the build and an example plantuml diagram

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     // jsoup is our awesome html parser, see jsoup.org
     compile group: 'org.jsoup', name: 'jsoup', version: '1.11.3'
 
-    //   gems 'rubygems:asciidoctor-diagram:1.4.0'
+    asciidoctor 'org.asciidoctor:asciidoctorj-diagram:1.5.8'
 
 } // dependencies
 
@@ -163,6 +163,8 @@ asciidoctor {
         }
         into "./images"
     }
+
+    requires = ['asciidoctor-diagram']
 
 } // asciidoctor
 

--- a/src/docs/hsc_arc42.adoc
+++ b/src/docs/hsc_arc42.adoc
@@ -80,6 +80,11 @@ Within the following text, the "Html Sanity Checker" shall be
 abbreviated with kbd:[HtmlSC]
 ====
 
+[plantuml,"firstDiagram",png]
+....
+include::plantuml/sequence1.puml[]
+....
+
 include::arc42/About-This-Docu.adoc[]
 
 include::arc42/chap-01-Requirements.adoc[]

--- a/src/docs/plantuml/sequence1.puml
+++ b/src/docs/plantuml/sequence1.puml
@@ -1,0 +1,23 @@
+@startuml
+skinparam maxmessagesize 80
+Gradle -> HSC: sanityCheckHtml()
+participant HSCTask as HSC
+activate HSC
+
+participant AllChecksRunner as ACR
+
+HSC -> HSC: cfg = setupConfiguration()
+HSC -> ACR: new AllChecksRunner(cfg)
+activate ACR
+
+ACR -> ACR: allFiles = FileCollector.getConfiguredHtmlFiles()
+ACR -> ACR: allCeckers = getAllCheckersByAnnotation
+ACR -> ACR: checkerz = instantiateCheckers
+loop allFiles
+    loop allCheckers
+    participant "Checker" as CHECK <<abstract>>
+    ACR -> CHECK: performSingleCheck(file)
+    end
+
+end
+@enduml


### PR DESCRIPTION
I've added asciidoc-diagram to the build just with two lines of code.

To give it a try and demonstrate it, I've added the sample sequence diagram to the start of the arc42 docs (yes, I know - this is the wrong place).

I've added the diagram by including it from the main document. That let's you maintain the diagram as extra file. Editors like INtelliJ handle this .puml file better than the inline version.