### PR TITLE
Be stricter when extracting HTTP/S hrefs

### DIFF
--- a/src/main/groovy/org/aim42/htmlsanitycheck/html/HtmlPage.groovy
+++ b/src/main/groovy/org/aim42/htmlsanitycheck/html/HtmlPage.groovy
@@ -1,5 +1,6 @@
 package org.aim42.htmlsanitycheck.html
 
+import java.util.regex.Pattern
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.jsoup.select.Elements
@@ -14,6 +15,12 @@ import org.jsoup.select.Elements
  * Relies on http://jsoup.org parser
  */
 class HtmlPage {
+
+    /**
+     * Pattern to check for HTTP/S scheme, includes the
+     * scheme separator (colon).
+     */
+    private static final Pattern HTTP_SCHEME_PATTERN = ~/(?i)^https?:/
 
     // jsoup Document
     private Document document
@@ -190,7 +197,7 @@ class HtmlPage {
 
         return elements
                 .collect{ it.attr("href")}
-                .findAll{ element -> element.toUpperCase().startsWith("HTTP") }
+                .findAll{ it =~ HTTP_SCHEME_PATTERN }
                 .toSet()
 
     }

--- a/src/test/groovy/org/aim42/htmlsanitycheck/html/HtmlPageSpec.groovy
+++ b/src/test/groovy/org/aim42/htmlsanitycheck/html/HtmlPageSpec.groovy
@@ -90,6 +90,8 @@ class HtmlPageSpec extends Specification {
         0             | """<img src="a.jpg"> """
         0             | """<a href="file://arc42.org">arc42</a>"""
         0             | """<a href="htpp://">bla</a> """
+        0             | """<a href="http.html">HTTP info</a> """
+        0             | """<a href="https.html">HTTPS info</a> """
 
         1             | """<a href="http://arc42.org">arc42</a>"""
         1             | """<a href="http://arc42.org">http</a>"""


### PR DESCRIPTION
Change HtmlPage.getAllHttpHrefStringsAsSet to also include the scheme
separator when matching the hrefs.
Update test to cover hrefs with local files that start with http and
https.

Fix #206 - Extraction of external links is too lenient