### PR TITLE
Make file scheme check locale independent

### DIFF
--- a/src/main/groovy/org/aim42/htmlsanitycheck/html/URLUtil.groovy
+++ b/src/main/groovy/org/aim42/htmlsanitycheck/html/URLUtil.groovy
@@ -123,7 +123,7 @@ class URLUtil {
 
     private static Boolean isLinkToFile(URI aUri) {
 
-        aUri?.getScheme()?.toUpperCase() == "FILE"
+        aUri?.getScheme()?.equalsIgnoreCase("file")
     }
 
     /**

--- a/src/test/groovy/org/aim42/htmlsanitycheck/html/URLUtilTest.groovy
+++ b/src/test/groovy/org/aim42/htmlsanitycheck/html/URLUtilTest.groovy
@@ -99,6 +99,21 @@ class URLUtilTest extends GroovyTestCase {
 
     }
 
+    @Test
+    public void testLinkToFileCheckDoesNotRelyOnDefaultLocale() {
+        Locale defaultLocale = Locale.getDefault()
+        try {
+            Locale.setDefault(new Locale("tr", "TR"))
+            List<String> localResources = ["file://test.html", "FILE://test.html"]
+
+            localResources.each { it ->
+                assertTrue("$it not recognized as local resource", URLUtil.isLocalResource(it))
+            }
+        } finally {
+            Locale.setDefault(defaultLocale)
+        }
+    }
+
     /**
      * tests if cross-references (intra-document-links) are recognized
      */


### PR DESCRIPTION
Change URLUtil.isLinkToFile to check the scheme with equalsIgnoreCase
instead of converting to upper case and use equals, the former does not
depend on the default locale.
Add test to assert the expected behaviour.

Fix #207 - File scheme check is locale dependent