### PR TITLE
[WIP] Correct resolution of local resources/images

### DIFF
--- a/src/main/groovy/org/aim42/htmlsanitycheck/check/MissingImageFilesChecker.groovy
+++ b/src/main/groovy/org/aim42/htmlsanitycheck/check/MissingImageFilesChecker.groovy
@@ -13,15 +13,15 @@ import org.slf4j.LoggerFactory
 
 class MissingImageFilesChecker extends Checker {
 
-    // members are initialized in implicit constructor
     private List<HtmlElement> images
-    private String baseDirPath
+    private File baseDir
+    private File currentDir
 
     // logging stuff
     private final static Logger logger = LoggerFactory.getLogger(MissingImageFilesChecker);
 
     public MissingImageFilesChecker() {
-        baseDirPath = Configuration.getConfigItemByName( Configuration.ITEM_NAME_sourceDir )
+        baseDir = Configuration.getConfigItemByName( Configuration.ITEM_NAME_sourceDir )
     }
 
     @Override
@@ -35,6 +35,7 @@ class MissingImageFilesChecker extends Checker {
 
     @Override
     protected SingleCheckResults check(final HtmlPage pageToCheck) {
+        currentDir = pageToCheck.file?.parentFile ?: baseDir
 
         //get list of all image-tags "<img..." in html file
         images = pageToCheck.getAllImageTags()
@@ -78,13 +79,10 @@ class MissingImageFilesChecker extends Checker {
     * @param relativePathToImageFile == XYZ in <img src="XYZ">
      **/
     private void doesImageFileExist(String relativePathToImageFile) {
-        // problem: if the relativePath is "./images/fileName.jpg",
-        // we need to add the appropriate path prefix...
-
-        String absolutePath = baseDirPath + "/" + relativePathToImageFile
+        File parentDir = relativePathToImageFile?.startsWith("/") ? baseDir : currentDir;
 
 
-        File imageFile = new File(absolutePath);
+        File imageFile = new File(parentDir, relativePathToImageFile);
 
         if (!imageFile.exists() || imageFile.isDirectory()) {
             String findingText = "image \"$relativePathToImageFile\" missing"

--- a/src/main/groovy/org/aim42/htmlsanitycheck/check/MissingLocalResourcesChecker.groovy
+++ b/src/main/groovy/org/aim42/htmlsanitycheck/check/MissingLocalResourcesChecker.groovy
@@ -2,6 +2,7 @@ package org.aim42.htmlsanitycheck.check
 
 import org.aim42.htmlsanitycheck.html.HtmlPage
 import org.aim42.htmlsanitycheck.html.URLUtil
+import org.aim42.htmlsanitycheck.Configuration
 import org.aim42.htmlsanitycheck.collect.SingleCheckResults
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -19,9 +20,16 @@ class MissingLocalResourcesChecker extends Checker {
     // created from the List of all by toSet() method
     private Set<String> localResourcesSet
 
-    // we need to know the baseDir of the html file, so we can check
-    // for local resources either with relative or absolute paths
-    private String baseDirPath
+    /**
+     * The base directory to resolve absolute paths.
+     */
+    private File baseDir
+
+    /**
+     * The current directory, obtained from the HtmlPage, to resolve
+     * relative paths.
+     */
+    private File currentDir
 
     /**
      * True to require files to be referenced and not directories. Useful if the web server doesn't
@@ -31,6 +39,10 @@ class MissingLocalResourcesChecker extends Checker {
 
     // logging stuff
     private final static Logger logger = LoggerFactory.getLogger(MissingLocalResourcesChecker.class);
+
+    public MissingLocalResourcesChecker() {
+        baseDir = Configuration.getConfigItemByName( Configuration.ITEM_NAME_sourceDir )
+    }
 
     @Override
     protected void initCheckingResultsDescription() {
@@ -54,12 +66,7 @@ class MissingLocalResourcesChecker extends Checker {
 
         logger.debug """local resources set: ${localResourcesSet}"""
 
-        // make sure we have a non-null baseDir
-        // (for html pages given as "string", this should be "")
-        if (baseDirPath == null) {
-            logger.info "no baseDir given, set to empty string."
-            baseDirPath = ""
-        }
+        currentDir = pageToCheck.file?.parentFile ?: baseDir
 
         // perform the actual checks
         checkAllLocalResources( localResourcesSet )
@@ -98,8 +105,15 @@ class MissingLocalResourcesChecker extends Checker {
         // we need to strip the localResource of #anchor-parts
         String localResourcePath = new URI( localResource ).getPath()
 
+        if (localResourcePath == null) {
+            // For example, javascript:;
+            return
+        }
+
+        File parentDir = localResourcePath?.startsWith("/") ? baseDir : currentDir;
+
         // we need the baseDir for robust checking of local resources...
-        File localFile = new File( baseDirPath, localResourcePath );
+        File localFile = new File( parentDir, localResourcePath );
 
         // action required if resource does not exist
         if (!localFile.exists() || (requireFiles && !localFile.isFile())) {

--- a/src/main/groovy/org/aim42/htmlsanitycheck/html/HtmlPage.groovy
+++ b/src/main/groovy/org/aim42/htmlsanitycheck/html/HtmlPage.groovy
@@ -26,6 +26,11 @@ class HtmlPage {
     private Document document
 
     /**
+     * The HTML file.
+     */
+    private File file
+
+    /**
      *
      * @param text html as text (string)
      * @return an HtmlPage
@@ -43,6 +48,7 @@ class HtmlPage {
      */
     public HtmlPage(File file) {
         assert file.exists()
+        this.file = file
         document = Jsoup.parse(file, "UTF-8")
     }
 
@@ -55,6 +61,13 @@ class HtmlPage {
         return new HtmlPage(fileToCheck)
     }
 
+    /**
+     * Gets the file of the HTML page.
+     * @return the file, or null if the HTML is not from a file.
+     */
+    public File getFile() {
+        return file;
+    }
 
     /**
      * get document meta info (e.g. filename, title, size etc.)

--- a/src/test/groovy/org/aim42/htmlsanitycheck/AllChecksRunnerTest.groovy
+++ b/src/test/groovy/org/aim42/htmlsanitycheck/AllChecksRunnerTest.groovy
@@ -22,7 +22,7 @@ class AllChecksRunnerTest extends GroovyTestCase {
         tmpFile = File.createTempFile("testfile", ".html") <<HTML
 
         Configuration.addConfigurationItem( Configuration.ITEM_NAME_sourceDocuments, tmpFile.name)
-        Configuration.addConfigurationItem( Configuration.ITEM_NAME_sourceDir, tmpFile?.getAbsoluteFile().getParent())
+        Configuration.addConfigurationItem( Configuration.ITEM_NAME_sourceDir, tmpFile.parentFile)
 
 
         // wrap fileToTest in Collection to comply to AllChecksRunner API
@@ -62,7 +62,7 @@ class AllChecksRunnerTest extends GroovyTestCase {
         tmpFile = File.createTempFile("testfile", ".html") << HTML
 
         Configuration.addConfigurationItem( Configuration.ITEM_NAME_sourceDocuments, tmpFile.name)
-        Configuration.addConfigurationItem( Configuration.ITEM_NAME_sourceDir, tmpFile?.getAbsoluteFile().getParent())
+        Configuration.addConfigurationItem( Configuration.ITEM_NAME_sourceDir, tmpFile.parentFile)
 
         allChecksRunner = new AllChecksRunner(  )
 

--- a/src/test/groovy/org/aim42/htmlsanitycheck/check/CheckerCreatorSpec.groovy
+++ b/src/test/groovy/org/aim42/htmlsanitycheck/check/CheckerCreatorSpec.groovy
@@ -117,7 +117,7 @@ class CheckerCreatorSpec extends Specification {
         MissingImageFilesChecker oneChecker
 
         when:
-        Configuration.addConfigurationItem( Configuration.ITEM_NAME_sourceDir, new File('.').canonicalPath)
+        Configuration.addConfigurationItem( Configuration.ITEM_NAME_sourceDir, new File('.'))
         oneChecker = CheckerCreator.createSingleChecker(MissingImageFilesChecker.class)
 
         // performCheck method returns SingleCheckResults
@@ -128,14 +128,15 @@ class CheckerCreatorSpec extends Specification {
         then:'performCheck method is present'
         notThrown(NoSuchMethodException)
         pMethod == fullDeclaration
-		and:'baseDirPath is present'
-		oneChecker.baseDirPath
+		and:'baseDir is present'
+		oneChecker.baseDir
     }
 
 	def "can create MissingLocalResourcesChecker instance"() {
         MissingLocalResourcesChecker oneChecker
 
         when:
+        Configuration.addConfigurationItem( Configuration.ITEM_NAME_sourceDir, new File('.'))
         oneChecker = CheckerCreator.createSingleChecker(MissingLocalResourcesChecker.class)
 
         // performCheck method returns SingleCheckResults
@@ -146,9 +147,8 @@ class CheckerCreatorSpec extends Specification {
         then:'performCheck method is present'
         notThrown(NoSuchMethodException)
         pMethod == fullDeclaration
-		// TODO: for issue #210, we have to review and check the following assertion:
-        //and:'baseDirPath is present'
-		//oneChecker.baseDirPath
+        and:'baseDir is present'
+        oneChecker.baseDir
     }
 }
 

--- a/src/test/groovy/org/aim42/htmlsanitycheck/check/MissingImageFilesCheckerTest.groovy
+++ b/src/test/groovy/org/aim42/htmlsanitycheck/check/MissingImageFilesCheckerTest.groovy
@@ -71,7 +71,7 @@ class MissingImageFilesCheckerTest extends GroovyTestCase {
         List<HtmlElement> images = htmlPage.getAllImageTags()
         assertEquals( "expected 1 image", 1, images.size())
 
-        Configuration.addConfigurationItem(Configuration.ITEM_NAME_sourceDir, "")
+        Configuration.addConfigurationItem(Configuration.ITEM_NAME_sourceDir, new File(""))
         checker = new MissingImageFilesChecker( )
 
         checkingResults = checker.performCheck( htmlPage )
@@ -133,7 +133,8 @@ class MissingImageFilesCheckerTest extends GroovyTestCase {
 
         assertNotNull("htmlpage must not be null", htmlPage )
 
-        checker = new MissingImageFilesChecker( baseDirPath: imagesDir)
+        Configuration.addConfigurationItem(Configuration.ITEM_NAME_sourceDir, new File(imagesDir) )
+        checker = new MissingImageFilesChecker()
 
         checkingResults = checker.performCheck( htmlPage )
 
@@ -170,7 +171,8 @@ class MissingImageFilesCheckerTest extends GroovyTestCase {
         List<HtmlElement> images = htmlPage.getAllImageTags()
         assertEquals( "expected 1 image", 1, images.size())
 
-        checker = new MissingImageFilesChecker( baseDirPath: tempFolder)
+        Configuration.addConfigurationItem(Configuration.ITEM_NAME_sourceDir, tempFolder )
+        checker = new MissingImageFilesChecker()
 
         checkingResults = checker.performCheck( htmlPage )
 

--- a/src/test/groovy/org/aim42/htmlsanitycheck/check/MissingLocalResourceRefCountSpec.groovy
+++ b/src/test/groovy/org/aim42/htmlsanitycheck/check/MissingLocalResourceRefCountSpec.groovy
@@ -1,5 +1,6 @@
 package org.aim42.htmlsanitycheck.check
 
+import org.aim42.htmlsanitycheck.Configuration
 import org.aim42.htmlsanitycheck.collect.SingleCheckResults
 import org.aim42.htmlsanitycheck.html.HtmlConst
 import org.aim42.htmlsanitycheck.html.HtmlPage
@@ -51,8 +52,10 @@ class MissingLocalResourceRefCountSpec extends Specification {
 
         HtmlPage htmlPage = new HtmlPage( tmpHtmlFile )
 
+        Configuration.addConfigurationItem(Configuration.ITEM_NAME_sourceDir, tmpDir )
+
         when:
-        def missingLocalResourcesChecker = new MissingLocalResourcesChecker( baseDirPath: tmpDir )
+        def missingLocalResourcesChecker = new MissingLocalResourcesChecker()
         SingleCheckResults collector = missingLocalResourcesChecker.performCheck( htmlPage )
 
 

--- a/src/test/groovy/org/aim42/htmlsanitycheck/check/MissingLocalResourcesCheckerTest.groovy
+++ b/src/test/groovy/org/aim42/htmlsanitycheck/check/MissingLocalResourcesCheckerTest.groovy
@@ -1,5 +1,6 @@
 package org.aim42.htmlsanitycheck.check
 
+import org.aim42.htmlsanitycheck.Configuration
 import org.aim42.htmlsanitycheck.collect.SingleCheckResults
 import org.aim42.htmlsanitycheck.html.HtmlConst
 import org.aim42.htmlsanitycheck.html.HtmlPage
@@ -31,11 +32,12 @@ class MissingLocalResourcesCheckerTest extends GroovyTestCase {
 
         assertTrue( "newly created html file exists", index.exists())
 
+        Configuration.addConfigurationItem(Configuration.ITEM_NAME_sourceDir, d1 )
 
         // 4.) check
         htmlPage = new HtmlPage( index )
 
-        missingLocalResourcesChecker = new MissingLocalResourcesChecker( baseDirPath: d1.canonicalPath )
+        missingLocalResourcesChecker = new MissingLocalResourcesChecker()
         collector = missingLocalResourcesChecker.performCheck( htmlPage )
 
         // assert that no issue is found (== the local resource d2/fname.html is found)
@@ -57,6 +59,8 @@ class MissingLocalResourcesCheckerTest extends GroovyTestCase {
 
         assertTrue( "newly created html file exists", index.exists())
 
+        Configuration.addConfigurationItem(Configuration.ITEM_NAME_sourceDir, d1 )
+
         htmlPage = new HtmlPage( index )
 
         // pageToCheck shall contain ONE local resource / local-reference
@@ -68,7 +72,7 @@ class MissingLocalResourcesCheckerTest extends GroovyTestCase {
         assertEquals( "expected d2/fname#anchor", "d2/$fname#anchor", localReference)
 
 
-        missingLocalResourcesChecker = new MissingLocalResourcesChecker( baseDirPath: d1.canonicalPath )
+        missingLocalResourcesChecker = new MissingLocalResourcesChecker()
         collector = missingLocalResourcesChecker.performCheck( htmlPage )
 
         // assert that no issue is found
@@ -159,12 +163,14 @@ class MissingLocalResourcesCheckerTest extends GroovyTestCase {
 <body><p><a href="/files/doc.pdf" /></p></body>
 </html>"""
 		
+		Configuration.addConfigurationItem(Configuration.ITEM_NAME_sourceDir, tempFolder )
+
         htmlPage = new HtmlPage( htmlFile )
 
         int nrOfLocalReferences = htmlPage.getAllHrefStrings().size()
         assertEquals( "expected one reference", 1, nrOfLocalReferences)
 
-        missingLocalResourcesChecker = new MissingLocalResourcesChecker( baseDirPath: tempFolder)
+        missingLocalResourcesChecker = new MissingLocalResourcesChecker()
 
         collector = missingLocalResourcesChecker.performCheck( htmlPage )
 

--- a/src/test/groovy/org/aim42/htmlsanitycheck/collect/SingleCheckResultsTest.groovy
+++ b/src/test/groovy/org/aim42/htmlsanitycheck/collect/SingleCheckResultsTest.groovy
@@ -1,5 +1,6 @@
 package org.aim42.htmlsanitycheck.collect
 
+import org.aim42.htmlsanitycheck.Configuration
 import org.aim42.htmlsanitycheck.check.Checker
 import org.aim42.htmlsanitycheck.check.MissingImageFilesChecker
 import org.aim42.htmlsanitycheck.html.HtmlElement
@@ -32,6 +33,7 @@ class SingleCheckResultsTest extends GroovyTestCase {
 
         imageDir = new File(".").getCanonicalPath() + localPath
 
+        Configuration.addConfigurationItem(Configuration.ITEM_NAME_sourceDir, new File(imageDir) )
 
     }
 
@@ -80,7 +82,7 @@ class SingleCheckResultsTest extends GroovyTestCase {
         List<HtmlElement> images = htmlPage.getAllImageTags()
         assertEquals("expected 2 images", 2, images.size())
 
-        checker = new MissingImageFilesChecker( baseDirPath: imageDir)
+        checker = new MissingImageFilesChecker()
 
         SingleCheckResults checkingResults = checker.performCheck( htmlPage )
 


### PR DESCRIPTION
This is still work in progress (missing test cases and docs), sharing before being finished to get feedback about the implementation/logic when resolving the local links.

The checkers `MissingImageFilesChecker` and `MissingLocalResourcesChecker` are now using two directories to resolve the links, the base directory (`sourceDir`) to resolve absolute links (ones that start with `/`) and the directory where the file is to resolve relative links (`file.html`, `./file.html`, `../file.html`).

The directory where the file is is obtained from the `HtmlPage`, which is now exposing the `File` it belongs to.
Both checkers end up doing the same logic so it might worth extracting a base class.

Fix for #210 and, eventually, #153.