### PR TITLE
Asciidoc setup with docToolchain container

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "docToolchain"]
-	path = docToolchain
-	url = https://github.com/docToolchain/docToolchain.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ git:
     submodules: false
 # Use sed to replace the SSH URL with the public URL, then initialize submodules
 before_install:
-    - sed -i 's/git@github.com:/https:\/\/github.com\//' .gitmodules
     - git submodule update --init --recursive
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -13,13 +13,14 @@ buildscript {
 }
 
 plugins {
+    id 'org.asciidoctor.convert' version '1.5.3'
     id 'groovy'
     id 'java'
     id "com.gradle.plugin-publish" version "0.9.10"
 
     // to report build results back to gradle.org
     id 'com.gradle.build-scan' version '1.16'
-
+    id "org.aim42.htmlSanityCheck" version "1.0.0"
 }
 
 repositories {
@@ -71,6 +72,9 @@ apply plugin: 'java-gradle-plugin'
 // Groovy source files using CodeNarc and generates reports from these checks.
 apply plugin: 'codenarc'
 
+// asciidoctor conversion
+apply plugin: 'org.asciidoctor.convert'
+
 // publish to gradle-plugin-repository
 apply plugin: "com.gradle.plugin-publish"
 
@@ -82,6 +86,18 @@ apply from: 'config/codenarc.gradle'
 
 // end:BuildPlugins[]
 
+htmlSanityCheck {
+    sourceDir = new File( buildDir, "html5")
+
+    // files to check - in Set-notation
+    //sourceDocuments = [ "one-file.html", "another-file.html", "index.html"]
+
+    // where to put results of sanityChecks...
+    checkingResultsDir = new File( buildDir, "reports/tests/htmlSanityCheck" )
+
+    // don't break the build if html errors are found!
+    failOnErrors = false
+}
 
 task copyResourceImages(type: Copy) {
     from('src/main/resources') {
@@ -99,23 +115,50 @@ processResources {
 
 // ========================================================
 
-
-//configure docToolchain to use the main project's config
-project('docToolchain') {
-    if (project.hasProperty('docDir')) {
-        docDir = '../.'
-        mainConfigFile = 'config/docToolchain.groovy'
-    } else {
-        println "="*80
-        println "  please initialize the docToolchain submodule by executing"
-        println "  git submodule update -i"
-        println "="*80
+asciidoctor {
+    outputDir = file(buildDir)
+    sourceDir = file(srcDir)
+    sources {
+        include "hsc_arc42.adoc",
+                "index.adoc",
+                "DevelopmentGuide.adoc"
     }
-}
+
+    attributes = [
+            doctype             : 'book',
+            icons               : 'font',
+            toc                 : 'left',
+            sectlink            : true,
+            sectanchors         : true,
+            numbered            : true,
+            'source-highlighter': 'coderay',
+            'javaVersion'       : "$javaVersion",
+            'currentDate'       : "$currentDate",
+            'versionId'         : "$version"]
+
+    resources {
+        from("${srcDir}/images") {
+            include '**'
+        }
+        into "./images"
+    }
+
+} // asciidoctor
 
 task generateDocs (
-        dependsOn: ['docToolchain:exportExcel', 'docToolchain:generateHTML', 'docToolchain:htmlSanityCheck']
-) { }
+        type: Exec,
+        group: 'docToolchain',
+        description: 'executes all steps to generate docs through docToolchain docker container'
+) {
+//    ignoreExitValue = true
+    workingDir "$projectDir"
+    if (System.getProperty("os.name").toUpperCase().contains("WINDOWS")) {
+        executable = "$projectDir/doctoolchain.bat"
+    } else {
+        executable = "$projectDir/doctoolchain.sh"
+    }
+    args = ['exportExcel', 'generateHTML', 'htmlSanityCheck']
+}
 
 // ==========================================================
 // if you use htmlSanityCheck locally, publish with

--- a/doctoolchain.bat
+++ b/doctoolchain.bat
@@ -1,0 +1,1 @@
+docker run --rm --entrypoint /bin/bash -it -v %cd%:/project rdmueller/doctoolchain:rc-1.0.0 -c "doctoolchain . %1 %2 %3 %4 %5 %6 %7 %8 %9 -PmainConfigFile=config/docToolchain.groovy && exit"

--- a/doctoolchain.bat
+++ b/doctoolchain.bat
@@ -1,1 +1,1 @@
-docker run --rm --entrypoint /bin/bash -it -v %cd%:/project rdmueller/doctoolchain:rc-1.0.0 -c "doctoolchain . %1 %2 %3 %4 %5 %6 %7 %8 %9 -PmainConfigFile=config/docToolchain.groovy && exit"
+docker run --rm --entrypoint /bin/bash  -v %cd%:/project rdmueller/doctoolchain:rc-1.0.0 -c "doctoolchain . %1 %2 %3 %4 %5 %6 %7 %8 %9 -PmainConfigFile=config/docToolchain.groovy --stacktrace && exit"

--- a/doctoolchain.sh
+++ b/doctoolchain.sh
@@ -1,4 +1,4 @@
-docker run --rm --entrypoint /bin/bash -it -v ${PWD}:/project rdmueller/doctoolchain:rc-1.0.0 \
+docker run --rm --entrypoint /bin/bash  -v ${PWD}:/project rdmueller/doctoolchain:rc-1.0.0 \
 -c "doctoolchain . $1 $2 $3 $4 $5 $6 $7 $8 $9 -PmainConfigFile=config/docToolchain.groovy && exit"
 
 

--- a/doctoolchain.sh
+++ b/doctoolchain.sh
@@ -1,0 +1,4 @@
+docker run --rm -it -v ${PWD}:/project rdmueller/doctoolchain:snapshot-0.1.10 \
+-c "doctoolchain . $1 $2 $3 $4 $5 $6 $7 $8 $9 -PmainConfigFile=config/docToolchain.groovy && exit"
+
+

--- a/doctoolchain.sh
+++ b/doctoolchain.sh
@@ -1,4 +1,4 @@
-docker run --rm -it -v ${PWD}:/project rdmueller/doctoolchain:snapshot-0.1.10 \
+docker run --rm --entrypoint /bin/bash -it -v ${PWD}:/project rdmueller/doctoolchain:rc-1.0.0 \
 -c "doctoolchain . $1 $2 $3 $4 $5 $6 $7 $8 $9 -PmainConfigFile=config/docToolchain.groovy && exit"
 
 

--- a/src/docs/website/_config.yml
+++ b/src/docs/website/_config.yml
@@ -120,6 +120,18 @@ kramdown:
   smart_quotes: lsquo,rsquo,ldquo,rdquo
   enable_coderay: false
 
+# Asciidoc stuff
+asciidoc:
+  processor: asciidoctor
+  ext: asciidoc,adoc,ad
+
+asciidoctor:
+  safe: unsafe
+  attributes:
+  - idseparator=_
+  - source-highlighter=coderay
+#  - pygments-css=class
+
 
 # Sass/SCSS
 sass:
@@ -140,6 +152,7 @@ plugins:
   - jekyll-feed
   - jemoji
   - jekyll-include-cache
+  - jekyll-asciidoc
 
 # mimic GitHub Pages with --safe
 whitelist:

--- a/src/docs/website/_layouts/asciidoc.html
+++ b/src/docs/website/_layouts/asciidoc.html
@@ -17,8 +17,8 @@
             #toc.toc {
                 position: fixed;
                 left: 0px;
-                width: 20em;
-                font-size: small;
+                width: 14em;
+                font-size: 0.8em;
                 overflow: auto;
                 z-index: 1000;
                 padding: 0.5em;
@@ -37,8 +37,8 @@
             }
 
             div#main-content {
-                font-size: small;
-                padding-left: 22em;
+                xfont-size: small;
+                padding-left: 14em;
                 padding-right: 2em;
                 padding-top: 80px;
             }


### PR DESCRIPTION
the docToolchain submodule has been replaced with a container

    ./gradlew generateDocs

will now generate the docs through the docToolchain container.

the project now also has its independent `htmlSanityCheck`-task back:

    ./gradlew htmlSanityCheck

PS: the docToolchain container is pulled from the docker hub - it is defined in this repository https://github.com/docToolchain/docker-image and build on the docker hub - on change.
It already contains all dependencies which makes the execution quite fast (when it is already downloaded)