### PR TITLE
fix access qualifier #196

### DIFF
--- a/src/main/groovy/org/aim42/htmlsanitycheck/Configuration.groovy
+++ b/src/main/groovy/org/aim42/htmlsanitycheck/Configuration.groovy
@@ -83,7 +83,7 @@ class Configuration {
 
 
     // constructor to set (some) default values
-    private Configuration() {
+    Configuration() {
 
         this.configurationItems.put(ITEM_NAME_httpErrorCodes, NetUtil.HTTP_ERROR_CODES)
         this.configurationItems.put(ITEM_NAME_httpSuccessCodes, NetUtil.HTTP_SUCCESS_CODES)
@@ -103,7 +103,7 @@ class Configuration {
      * @param itemName
      * @return
      */
-    public synchronized Object getConfigItemByName(final String itemName) {
+    synchronized Object getConfigItemByName(final String itemName) {
         return configurationItems.get(itemName)
     }
 
@@ -121,7 +121,7 @@ class Configuration {
     /**
      * @return true if item is already present, false otherwise
      */
-    public boolean checkIfItemPresent(String itemName) {
+    boolean checkIfItemPresent(String itemName) {
         boolean result = false
         if (configurationItems.get(itemName) != null) {
             result = true
@@ -221,7 +221,7 @@ class Configuration {
      * srcDocs needs to be of type {@link org.gradle.api.file.FileCollection}
      * to be Gradle-compliant
      */
-    public Boolean isValid() {
+    Boolean isValid() {
 
         // we need at least srcDir and srcDocs!!
         File srcDir = getConfigItemByName(Configuration.ITEM_NAME_sourceDir)
@@ -258,7 +258,7 @@ class Configuration {
 
 
     @Override
-    public String toString() {
+    String toString() {
         return "Configuration{" +
                 "configurationItems=" + configurationItems +
                 '}';

--- a/src/test/groovy/org/aim42/htmlsanitycheck/check/BrokenHttpLinksCheckerSpec.groovy
+++ b/src/test/groovy/org/aim42/htmlsanitycheck/check/BrokenHttpLinksCheckerSpec.groovy
@@ -182,7 +182,7 @@ class BrokenHttpLinksCheckerSpec extends Specification {
     def 'bad link #badLink is recognized as such'() {
 
         given: "an HTML page with a single (broken) link"
-        String goodURL = "https://httpstat.us/${badLink}"
+        String goodURL = "https://mock.codes/${badLink}"
         String HTML = """$HtmlConst.HTML_HEAD 
                 <a href=${goodURL}>${badLink}</a>
                 $HtmlConst.HTML_END """


### PR DESCRIPTION
- remove unnecessary public qualifier
- remove private qualifier to fix forbidden access restriction in HtmlSanityCheckTask#setupConfiguration
- fix brokerlink test failure switch to mock.codes instead of httpstat.us (reacts for 504 not correctly)