### PR TITLE
Fix for https://github.com/aim42/htmlSanityCheck/issues/282

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,10 +16,6 @@ plugins {
     id 'groovy'
     id 'java'
     id "com.gradle.plugin-publish" version "0.9.10"
-
-    // to report build results back to gradle.org
-    id 'com.gradle.build-scan' version '2.2.1'
-
 }
 
 repositories {
@@ -29,13 +25,13 @@ repositories {
 
 dependencies {
 
-    testCompile(
+    testImplementation(
             'junit:junit:4.12',
             'org.spockframework:spock-core:1.2-groovy-2.5')
-    
-    compile gradleApi()
 
-    compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.3'
+    implementation gradleApi()
+
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.3'
 
     // since gradle 4.6, annotation processors shall be explicitly declared
     // (instead of just having them in the compile-group)
@@ -43,7 +39,7 @@ dependencies {
 
 
     // jsoup is our awesome html parser, see jsoup.org
-    compile group: 'org.jsoup', name: 'jsoup', version: '1.11.3'
+    implementation group: 'org.jsoup', name: 'jsoup', version: '1.11.3'
 
 
 } // dependencies

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 HtmlSanityCheck - ChangeLog
 
+V 1.3.snapshot
+Jan 2021: try to fix https://github.com/aim42/htmlSanityCheck/issues/282
+
 V.1.0.0-RC-2
 Oct 2018: enhanced configurability, fixed several bugs, released version on gradle plugin portal
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,8 @@
+plugins {
+    // to report build results back to gradle.org
+    id "com.gradle.enterprise" version "3.5.1"
+}
+
 rootProject.name = 'htmlSanityCheck'
 
-enableFeaturePreview('STABLE_PUBLISHING')
-
 include 'docToolchain'
-

--- a/src/main/groovy/org/aim42/htmlsanitycheck/HtmlSanityCheckTask.groovy
+++ b/src/main/groovy/org/aim42/htmlsanitycheck/HtmlSanityCheckTask.groovy
@@ -44,17 +44,17 @@ class HtmlSanityCheckTask extends DefaultTask {
 
     // configurable timeout for http-requests (used by @BrokenHttpLinksChecker)
     // defaults to 5000 (msecs)
-    @Optional
+    // java primitives must not be marked as @Optional
     @Input
     int httpConnectionTimeout = 5000
 
     // shall localhost-URLs lead to warnings?
-    @Optional
+    // java primitives must not be marked as @Optional
     @Input
     boolean ignoreLocalHost = false
 
     // shall numerical IP addresses lead to warnings?
-    @Optional
+    // java primitives must not be marked as @Optional
     @Input
     boolean ignoreIPAddresses = false
 

--- a/src/test/groovy/org/aim42/htmlsanitycheck/HtmlSanityCheckTaskFunctionalTest.groovy
+++ b/src/test/groovy/org/aim42/htmlsanitycheck/HtmlSanityCheckTaskFunctionalTest.groovy
@@ -15,7 +15,7 @@ import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 class HtmlSanityCheckTaskFunctionalTest extends Specification {
     private final static VALID_HTML = """<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN"><html><head></head><body></body><html>"""
     private final static INVALID_HTML = """<body><span id="id"/><span id="id"/></body> """
-    private final static GRADLE_VERSIONS = ['4.9']
+    private final static GRADLE_VERSIONS = ['6.8.1']
 
     @Rule
     final TemporaryFolder testProjectDir = new TemporaryFolder()
@@ -26,14 +26,19 @@ class HtmlSanityCheckTaskFunctionalTest extends Specification {
     def setup() {
         buildDir = testProjectDir.newFolder("build")
         htmlFile = testProjectDir.newFile("test.html")
+        // a note on writing paths to the build script on windows:
+        // - the default file separator is a backslash
+        // - as the path is written into a quoted string, backslashes should be quoted
+        // - to avoid string manipulation or similar, we use URIs to avoid the problem
+        //   (URIs consist of / instead of backslashes)
         buildFile = testProjectDir.newFile('build.gradle') << """
             plugins {
                 id 'org.aim42.htmlSanityCheck'
             }
             
             htmlSanityCheck {
-                sourceDir = file( "${htmlFile.parent}" )
-                checkingResultsDir = file( "${buildDir.absolutePath}" )
+                sourceDir = file( "${htmlFile.parentFile.toURI().path}" )
+                checkingResultsDir = file( "${buildDir.toURI().path}" )
             }
         """
     }

--- a/src/test/groovy/org/aim42/htmlsanitycheck/check/MissingLocalResourcesCheckerTest.groovy
+++ b/src/test/groovy/org/aim42/htmlsanitycheck/check/MissingLocalResourcesCheckerTest.groovy
@@ -142,8 +142,11 @@ class MissingLocalResourcesCheckerTest extends GroovyTestCase {
         final String fname = "fname.html"
         File f2 = new File(d2, fname) << HtmlConst.HTML_HEAD
 
-        assertEquals("created an artificial file", "d2/fname.html",
-                f2.canonicalPath - d1.canonicalPath - "/")
+        assertEquals("created an artificial file",
+                // unix: /d2/fname.html
+                // windows: \d2\fname.html
+                File.separator + "d2" + File.separator + "fname.html",
+                f2.canonicalPath - d1.canonicalPath)
 
         assertTrue("newly created artificial file exists", f2.exists())
 


### PR DESCRIPTION
hints:
- build.gradle/com.gradle.build-scan has been moved to settings.gradle (https://docs.gradle.com/enterprise/gradle-plugin/#gradle_6_x_and_later).
- gradle wrapper updated to current 6.8.1
- configuration names updated (testCompile -> testImplementation)
- feature preview 'STABLE_PUBLISHING' is not supported anymore in current gradle version
- java primitives must not be marked as @Optional

unchanged:
- doctoolchain/build.gradle: configuration names should get updated, too.

as commented in the issue, they have been failing testcases locally befor making the changes - and the tests still fail after my changes. at least running 'gradlew --warning-mode all' doesnt show any warnings / deprecations anymore.
