### PR TITLE
Track published outputs to avoid conflict with `:clean` task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -267,6 +267,11 @@ configure(subprojects) {
         }
     }
 
+    tasks.withType(PublishToMavenRepository).named { it.contains("MyLocalRepositoryForFullIntegrationTests") }.configureEach {
+        outputs.dir(mavenBuildRepo)
+        outputs.upToDateWhen { false }
+    }
+
     tasks.named('test', Test) {
         useJUnitPlatform()
     }


### PR DESCRIPTION
Tasks of type `PublishToMavenRepository` do not track their outputs as
they are typically used to publish to an external Maven repository.
However, here such tasks are used to publish to `build/maven-repo` in
the root project. Since Gradle's task graph was not aware of these
untracked outputs, the `:clean` task was allowed to run in parallel of
the subproject's publishing tasks. In some cases, this caused `:clean`
to fail; in other cases, the contents of the custom local Maven
repository were incomplete which caused downstream tasks to fail.

This should resolve the problem of running
`./gradlew clean check integrationTest` repeatedly.