### PR TITLE
Introduce Container‑based GitHub Action 

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -6,6 +6,10 @@ on:
         required: true
         type: string
         default: '17'
+      push-docker-sha:
+        required: false
+        type: boolean
+        default: false
       run-sonar:
         required: false
         type: boolean
@@ -21,6 +25,9 @@ env:
 
 jobs:
   build:
+    env:
+      DOCKER_USERNAME: ${{ github.repository_owner }}
+      DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
     runs-on: ubuntu-latest
     steps:
       - name: Check out
@@ -57,6 +64,14 @@ jobs:
       - name: Execute Gradle build
         run: ./gradlew clean check integrationTest build --scan --stacktrace
 
+      - name: Push Docker with Git SHA as tag for subsequent tests
+        if: ${{ inputs.push-docker-sha }}
+        run: |
+          ./gradlew dockerPush -Ddocker.image.additional.tags=${{ github.sha }}
+          docker pull "ghcr.io/aim42/hsc:${{ github.sha }}"
+          echo "Docker Images:"
+          docker images
+
       - name: Cache SonarCloud packages
         uses: actions/cache@v4
         if: ${{ inputs.run-sonar }}
@@ -82,6 +97,8 @@ jobs:
       - name: Collect state upon failure
         if: failure()
         run: |
+          echo "Docker Images:"
+          docker images
           echo "Git:"
           git status
           echo "Env:"

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -55,7 +55,7 @@ jobs:
         uses: gradle/actions/wrapper-validation@v4
 
       - name: Execute Gradle build
-        run: ./gradlew clean check integrationTest --scan --stacktrace
+        run: ./gradlew clean check integrationTest build --scan --stacktrace
 
       - name: Cache SonarCloud packages
         uses: actions/cache@v4

--- a/.github/workflows/cleanup-ghcr.yml
+++ b/.github/workflows/cleanup-ghcr.yml
@@ -1,0 +1,102 @@
+name: Clean up old GHCR images
+
+on:
+  schedule:
+    - cron: '0 2 * * *'  # every night at 02:00 UTC
+  workflow_dispatch:
+    inputs:
+      retention_days:
+        description: 'Delete images older than this many days'
+        required: false
+        default: '14'
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  cleanup-ghcr:
+    name: Remove timestamped images older than 14 days
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'schedule' || github.ref == 'refs/heads/main' }}
+    steps:
+      - name: Clean up old container versions
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const org = 'aim42';
+            const package_type = 'container';
+            const package_name = 'hsc';
+            const per_page = 100;
+            const tsTagRegex = /^\d{14}$/; // yyyyMMddHHmmss
+            const daysInput = (context.payload && context.payload.inputs && context.payload.inputs.retention_days) || '14';
+            const daysParsed = parseInt(daysInput, 10);
+            const retentionDays = Number.isFinite(daysParsed) && daysParsed > 0 ? daysParsed : 14;
+            const cutoff = new Date(Date.now() - retentionDays * 24 * 60 * 60 * 1000); // retentionDays days ago
+            core.info(`Using retention period: ${retentionDays} day(s).`);
+
+            function parseTimestampTag(tag) {
+              // tag format: yyyyMMddHHmmss, interpreted as UTC
+              const y = parseInt(tag.slice(0, 4), 10);
+              const m = parseInt(tag.slice(4, 6), 10) - 1;
+              const d = parseInt(tag.slice(6, 8), 10);
+              const hh = parseInt(tag.slice(8, 10), 10);
+              const mm = parseInt(tag.slice(10, 12), 10);
+              const ss = parseInt(tag.slice(12, 14), 10);
+              return new Date(Date.UTC(y, m, d, hh, mm, ss));
+            }
+
+            let page = 1;
+            let totalDeleted = 0;
+            let scanned = 0;
+
+            while (true) {
+              const { data: versions } = await github.request(
+                'GET /orgs/{org}/packages/{package_type}/{package_name}/versions',
+                { org, package_type, package_name, per_page, page }
+              );
+
+              if (!versions || versions.length === 0) break;
+
+              for (const v of versions) {
+                scanned++;
+                const tags = (v.metadata && v.metadata.container && v.metadata.container.tags) || [];
+                if (!tags || tags.length === 0) continue;
+
+                // Skip protected tags to avoid removing latest or release tags that share the same version
+                const hasProtected = tags.some(t => t === 'latest' || /^v\d+/.test(t));
+                if (hasProtected) {
+                  core.info(`Skipping protected version ${v.id} with tags: ${tags.join(', ')}`);
+                  continue;
+                }
+
+                const tsTags = tags.filter(t => tsTagRegex.test(t));
+                if (tsTags.length === 0) continue;
+
+                // If any timestamp tag is older than cutoff, delete the entire version
+                let shouldDelete = tsTags.some(t => parseTimestampTag(t) < cutoff);
+
+                if (shouldDelete) {
+                  try {
+                    await github.request(
+                      'DELETE /orgs/{org}/packages/{package_type}/{package_name}/versions/{package_version_id}',
+                      {
+                        org,
+                        package_type,
+                        package_name,
+                        package_version_id: v.id,
+                      }
+                    );
+                    totalDeleted++;
+                    core.info(`Deleted version ${v.id} with tags: ${tags.join(', ')}`);
+                  } catch (err) {
+                    core.warning(`Failed to delete version ${v.id}: ${err.message}`);
+                  }
+                }
+              }
+
+              page++;
+            }
+
+            core.info(`Scanned versions: ${scanned}. Deleted versions: ${totalDeleted}.`);

--- a/.github/workflows/cleanup-ghcr.yml
+++ b/.github/workflows/cleanup-ghcr.yml
@@ -9,6 +9,11 @@ on:
         description: 'Delete images older than this many days'
         required: false
         default: '14'
+      dry_run:
+        description: 'If true, only print which versions would be deleted (no deletion performed)'
+        required: false
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -30,11 +35,18 @@ jobs:
             const package_name = 'hsc';
             const per_page = 100;
             const tsTagRegex = /^\d{14}$/; // yyyyMMddHHmmss
+            const sha256Regex = /^[a-f0-9]{64}$/i; // sha256 digest-like tag
+
             const daysInput = (context.payload && context.payload.inputs && context.payload.inputs.retention_days) || '14';
             const daysParsed = parseInt(daysInput, 10);
             const retentionDays = Number.isFinite(daysParsed) && daysParsed > 0 ? daysParsed : 14;
             const cutoff = new Date(Date.now() - retentionDays * 24 * 60 * 60 * 1000); // retentionDays days ago
-            core.info(`Using retention period: ${retentionDays} day(s).`);
+
+            const dryRunInput = context.payload && context.payload.inputs ? context.payload.inputs.dry_run : undefined;
+            const dryRun = (typeof dryRunInput === 'boolean') ? dryRunInput
+              : (dryRunInput === undefined ? true : String(dryRunInput).toLowerCase() === 'true');
+
+            core.info(`Using retention period: ${retentionDays} day(s). Dry-run: ${dryRun}.`);
 
             function parseTimestampTag(tag) {
               // tag format: yyyyMMddHHmmss, interpreted as UTC
@@ -49,6 +61,7 @@ jobs:
 
             let page = 1;
             let totalDeleted = 0;
+            let wouldDelete = 0;
             let scanned = 0;
 
             while (true) {
@@ -56,47 +69,80 @@ jobs:
                 'GET /orgs/{org}/packages/{package_type}/{package_name}/versions',
                 { org, package_type, package_name, per_page, page }
               );
-
+            
               if (!versions || versions.length === 0) break;
 
               for (const v of versions) {
                 scanned++;
                 const tags = (v.metadata && v.metadata.container && v.metadata.container.tags) || [];
-                if (!tags || tags.length === 0) continue;
+                const createdAt = new Date(v.created_at || v.updated_at || 0);
+
+                core.debug (`Checking version '${v.id}' (${v.name}) of '${createdAt}' with tags: '${tags.join(', ')}'`); 
 
                 // Skip protected tags to avoid removing latest or release tags that share the same version
-                const hasProtected = tags.some(t => t === 'latest' || /^v\d+/.test(t));
-                if (hasProtected) {
+                const isProtected = tags.some(t => t === 'latest' || /^v\d[\.\d]*/.test(t));
+                if (isProtected) {
                   core.info(`Skipping protected version ${v.id} with tags: ${tags.join(', ')}`);
                   continue;
                 }
 
                 const tsTags = tags.filter(t => tsTagRegex.test(t));
-                if (tsTags.length === 0) continue;
+                const shaTags = tags.filter(t => sha256Regex.test(t));
+                const nonShaTags = tags.filter(t => !sha256Regex.test(t));
+
+                let shouldDelete = false;
 
                 // If any timestamp tag is older than cutoff, delete the entire version
-                let shouldDelete = tsTags.some(t => parseTimestampTag(t) < cutoff);
+                if (tsTags.length > 0) {
+                  shouldDelete = tsTags.some(t => parseTimestampTag(t) < cutoff);
+                }
+
+                // Additionally handle versions that are tagged only by sha256 values.
+                // Delete if older than retention (by created_at/updated_at) unless there is any non-sha256 tag.
+                if (!shouldDelete && shaTags.length > 0 && nonShaTags.length === 0) {
+                  if (createdAt instanceof Date && !isNaN(createdAt) && createdAt < cutoff) {
+                    shouldDelete = true;
+                  }
+                }
+
+                // Handle versions with no tags at all: delete if older than retention by created/updated timestamp
+                if (!shouldDelete && (!tags || tags.length === 0)) {
+                  if (createdAt instanceof Date && !isNaN(createdAt) && createdAt < cutoff) {
+                    shouldDelete = true;
+                  }
+                }
 
                 if (shouldDelete) {
-                  try {
-                    await github.request(
-                      'DELETE /orgs/{org}/packages/{package_type}/{package_name}/versions/{package_version_id}',
-                      {
-                        org,
-                        package_type,
-                        package_name,
-                        package_version_id: v.id,
-                      }
-                    );
-                    totalDeleted++;
-                    core.info(`Deleted version ${v.id} with tags: ${tags.join(', ')}`);
-                  } catch (err) {
-                    core.warning(`Failed to delete version ${v.id}: ${err.message}`);
+                  if (dryRun) {
+                    wouldDelete++;
+                    core.info(`[DRY-RUN] Would delete version '${v.id}' (${v.name}) of '${createdAt}' with tags: '${tags.join(', ')}'`);
+                  } else {
+                    try {
+                      await github.request(
+                        'DELETE /orgs/{org}/packages/{package_type}/{package_name}/versions/{package_version_id}',
+                        {
+                          org,
+                          package_type,
+                          package_name,
+                          package_version_id: v.id,
+                        }
+                      );
+                      totalDeleted++;
+                      core.info(`Deleted version '${v.id}' (${v.name}) of '${createdAt}' with tags: ${tags.join(', ')}`);
+                    } catch (err) {
+                      core.warning(`Failed to delete version ${v.id}: ${err.message}`);
+                    }
                   }
+                } else {
+                  core.debug (`Not deleting '${v.id}' (${v.name}) of '${createdAt}' with tags: '${tags.join(', ')}'`); 
                 }
               }
 
               page++;
             }
 
-            core.info(`Scanned versions: ${scanned}. Deleted versions: ${totalDeleted}.`);
+            if (dryRun) {
+              core.info(`Scanned versions: ${scanned}. Would delete versions: ${wouldDelete}.`);
+            } else {
+              core.info(`Scanned versions: ${scanned}. Deleted versions: ${totalDeleted}.`);
+            }

--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -151,7 +151,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.gradle/caches
-          key: "${{ runner.os }}-gradle-caches }}"
+          key: "${{ runner.os }}-gradle-caches"
           restore-keys: ${{ runner.os }}-gradle-caches
 
       - name: Execute Gradle build

--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -58,3 +58,59 @@ jobs:
           echo "Files:"
           find * -ls
           ./gradlew javaToolchains
+
+  publish-docker-images:
+    needs: build-artifacts
+    permissions:
+      packages: write
+      contents: read
+    env:
+      DOCKER_USERNAME: ${{ github.repository_owner }}
+      DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Cache Gradle Toolchain JDKs
+        uses: actions/cache@v4
+        with:
+          path: ~/.gradle/jdks
+          key: "${{ runner.os }}-gradle-jdks"
+          restore-keys: ${{ runner.os }}-gradle-jdks
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' }}
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.gradle/caches
+          key: "${{ runner.os }}-gradle-caches }}"
+          restore-keys: ${{ runner.os }}-gradle-caches
+
+      - name: Execute Gradle build
+        run: ./gradlew dockerPush --scan --stacktrace
+
+      - name: Collect state upon failure
+        if: failure()
+        run: |
+          echo "Maven Repo:"
+          (cd $HOME && find .m2 -ls)
+          echo "Git:"
+          git status
+          echo "Env:"
+          env | sort
+          echo "PWD:"
+          pwd
+          echo "Files:"
+          find * -ls
+          ./gradlew javaToolchains

--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -18,6 +18,58 @@ jobs:
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
+  test-gh-action:
+    needs: build-artifacts
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out
+        uses: actions/checkout@v5
+
+      - name: Prepare Docker image for test
+        run: |
+          tag=$(git branch --show-current | tr '/' '-')
+          docker pull ghcr.io/aim42/hsc:${tag}
+          docker tag ghcr.io/aim42/hsc:${tag} ghcr.io/aim42/hsc:v2
+
+      - name: Download Artifacts
+        uses: actions/download-artifact@v5
+        with:
+          name: build-artifacts
+          path: .
+
+      - name: Run GH Action as provided by this repository
+        uses: ./
+        with:
+          args: -r build/gh-action-test-report integration-test/common/build/docs --exclude 'https://www\.baeldung\.com/.*' --fail-on-errors
+
+      - name: Upload GH Action test results
+        uses: actions/upload-artifact@v4
+        with:
+          path: build/gh-action-test-report
+
+      - name: Test Result of GH Action
+        run: |
+          if test -s build/gh-action-test-report/index.html; then
+            echo "Test Successful"
+          else
+            echo "Test Failed: Report not found" >&2
+            exit 1
+          fi
+
+      - name: Collect state upon failure
+        if: failure()
+        run: |
+          echo "Git:"
+          git status
+          echo "Env:"
+          env | sort
+          echo "PWD:"
+          pwd
+          echo "Files:"
+          find * -ls
+          ./gradlew javaToolchains
+
   post-build:
     needs: build-artifacts
     runs-on: ubuntu-latest
@@ -60,7 +112,7 @@ jobs:
           ./gradlew javaToolchains
 
   publish-docker-images:
-    needs: build-artifacts
+    needs: test-gh-action
     permissions:
       packages: write
       contents: read

--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -15,11 +15,15 @@ on:
 
 jobs:
   build-artifacts:
+    permissions:
+      packages: write
+      contents: read
     uses: ./.github/workflows/build-artifacts.yml
     with:
       # SonarQube requires JDK 17 or higher
       java-version: '17'
       run-sonar: ${{ github.repository == 'aim42/htmlSanityCheck' }}
+      push-docker-sha: true
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
@@ -33,9 +37,11 @@ jobs:
 
       - name: Prepare Docker image for test
         run: |
-          tag=$(git branch --show-current | tr '/' '-')
-          docker pull ghcr.io/aim42/hsc:${tag}
-          docker tag ghcr.io/aim42/hsc:${tag} ghcr.io/aim42/hsc:v2
+          tag="${{ github.sha }}"
+          docker pull "ghcr.io/aim42/hsc:${tag}"
+          echo "Docker Images:"
+          docker images
+          docker tag "ghcr.io/aim42/hsc:${tag}" ghcr.io/aim42/hsc:v2
 
       - name: Download Artifacts
         uses: actions/download-artifact@v5
@@ -65,6 +71,8 @@ jobs:
       - name: Collect state upon failure
         if: failure()
         run: |
+          echo "Docker Images:"
+          docker images
           echo "Git:"
           git status
           echo "Env:"
@@ -162,6 +170,8 @@ jobs:
       - name: Collect state upon failure
         if: failure()
         run: |
+          echo "Docker Images:"
+          docker images
           echo "Maven Repo:"
           (cd $HOME && find .m2 -ls)
           echo "Git:"

--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -7,6 +7,11 @@ on:
   pull_request:
   push:
   workflow_dispatch:
+    inputs:
+      additional_tags:
+        description: 'Additional tags for Docker images (comma-separated)'
+        required: false
+        type: string
 
 jobs:
   build-artifacts:
@@ -150,7 +155,9 @@ jobs:
           restore-keys: ${{ runner.os }}-gradle-caches
 
       - name: Execute Gradle build
-        run: ./gradlew dockerPush --scan --stacktrace
+        env:
+          ADDITIONAL_TAGS: ${{ inputs.additional_tags }}
+        run: ./gradlew dockerPush -Ddocker.image.additional.tags="${ADDITIONAL_TAGS}" --scan --stacktrace
 
       - name: Collect state upon failure
         if: failure()

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,15 @@
+name: 'hsc'
+description: |
+  HSC (HTML Sanity Check) is a fast and lightweight tool for checking HTML, links, and accessibility issues. 
+  It helps ensure clean, error-free web content and integrates seamlessly into CI/CD workflows.
+inputs:
+  args:
+    description: 'CLI arguments (cf. https://hsc.aim42.org/manual/20_cli.html)'
+    required: false
+runs:
+  using: 'docker'
+  image: 'docker://ghcr.io/aim42/hsc:v2'
+  entrypoint: '/bin/sh'
+  args:
+  - -c
+  - java -jar /hsc.jar ${{ inputs.args }}

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,6 @@ runs:
   using: 'docker'
   # If the image tag changes, e.g., to v3, the action in the test workflow (workflows/gradle-build.yml) must be adjusted accordingly
   image: 'docker://ghcr.io/aim42/hsc:v2'
-  entrypoint: '/bin/sh'
+  entrypoint: '/hsc.sh'
   args:
-  - -c
-  - java -jar /hsc.jar ${{ inputs.args }}
+    - ${{ inputs.args }}

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,7 @@ inputs:
     required: false
 runs:
   using: 'docker'
+  # If the image tag changes, e.g., to v3, the action in the test workflow (workflows/gradle-build.yml) must be adjusted accordingly
   image: 'docker://ghcr.io/aim42/hsc:v2'
   entrypoint: '/bin/sh'
   args:

--- a/build.gradle
+++ b/build.gradle
@@ -354,6 +354,7 @@ tasks.register("integrationTestOnly") {
     dependsOn(
             ':publishAllPublicationsToMyLocalRepositoryForFullIntegrationTestsRepository',
             ':htmlSanityCheck-cli:installDist',
+            ':htmlSanityCheck-cli:dockerBuildLocal'
     )
 
     doLast {

--- a/build.gradle
+++ b/build.gradle
@@ -354,7 +354,7 @@ tasks.register("integrationTestOnly") {
     dependsOn(
             ':publishAllPublicationsToMyLocalRepositoryForFullIntegrationTestsRepository',
             ':htmlSanityCheck-cli:installDist',
-            ':htmlSanityCheck-cli:dockerBuildLocal'
+            ':htmlSanityCheck-cli:dockerBuild'
     )
 
     doLast {

--- a/build.gradle
+++ b/build.gradle
@@ -354,7 +354,7 @@ tasks.register("integrationTestOnly") {
     dependsOn(
             ':publishAllPublicationsToMyLocalRepositoryForFullIntegrationTestsRepository',
             ':htmlSanityCheck-cli:installDist',
-            ':htmlSanityCheck-cli:dockerBuild'
+            ':htmlSanityCheck-cli:dockerBuildLocal'
     )
 
     doLast {

--- a/htmlSanityCheck-cli/Dockerfile
+++ b/htmlSanityCheck-cli/Dockerfile
@@ -1,0 +1,14 @@
+FROM eclipse-temurin:21-jre-alpine
+
+ARG DESCRIPTION='HSC (HTML Sanity Check) is a fast and lightweight tool for checking HTML, links, and accessibility issues.'
+ARG VERSION=Unknown
+
+LABEL version=${VERSION}
+LABEL org.opencontainers.image.description=${DESCRIPTION}
+
+COPY hsc.sh /hsc.sh
+RUN chmod 755 /hsc.sh
+
+COPY build/libs/htmlSanityCheck-cli-${VERSION}-all.jar /hsc.jar
+
+ENTRYPOINT ["/hsc.sh"]

--- a/htmlSanityCheck-cli/README.adoc
+++ b/htmlSanityCheck-cli/README.adoc
@@ -17,22 +17,47 @@ The Command Line Interface (CLI) module of HTML Sanity Check (xref:{xrefToManual
 
 == Installation (Command Line Interface)
 
-=== Prerequisites
+You can run HSC on your machine
+
+* As a <<sec:java-usage,Java application>>{nbsp}->{nbsp}<<sec:java-installation>>, or
+* As a <<sec:container-usage,Container>>{nbsp}->{nbsp}<<sec:container-installation>>, or
+
+
+[[sec:java-installation]]
+=== Java Installation
+
+==== Prerequisites
 
 The HSC CLI needs Java 8 (`java` executable) or higher on the respective OS search path (`+${PATH}+` on Linux/macOS, `%path%` on Windows).
 
-=== SDKMAN
+==== SDKMAN
 
 If you use https://sdkman.io[SDKMAN], you can install HSC as SDKMAN candidate: `sdk install hsc`.
 
-=== Download
+==== Download
 
-Alternatively,
+Alternatively, you can download and unpack the CLI release:
 
 * Download the HSC CLI from the https://github.com/aim42/htmlSanityCheck/releases[release{nbsp}page].
 * Unpack the file in a convenient place, e.g., `/usr/local/hsc`.
+* Add the unpacked bin directory to your path, e.g. (for Unix), `+PATH=${PATH}:/usr/local/hsc/bin+`.
+
+[[sec:container-installation]]
+=== Container (Docker) Installation
+
+Alternatively, you can use a local Container runtime (such as https://www.docker.com/[Docker] or https://podman.io/[Podman]) and execute HSC as a container.
+In this case, no preliminary installation is necessary (except for the container runtime) you can directly <<sec:container-usage,run HSC>>.
+
+[NOTE]
+====
+While HSC supports both Docker and Podman as container runtimes, our examples and automated tests currently only use Docker.
+The commands should work similarly with Podman by replacing `docker` with `podman` in the examples.
+====
 
 == Usage
+
+[[sec:java-usage]]
+=== Java usage
 
 Execute the CLI tool with the following command.
 If the `sourceDirectory` is omitted, HSC uses the current directory as base-directory to search for HTML files.
@@ -50,6 +75,69 @@ Windows::
 ----
 hsc.bat [ options ] [ sourceDirectory ]
 ----
+
+[[sec:container-usage]]
+=== Using the Container image
+
+You can run HSC without installing Java or the CLI by using the Container image published at the GitHub Container Registry:
+`ghcr.io/aim42/hsc`.
+
+Unix (shell) example (Linux/macOS)::
++
+[source,sh]
+----
+# Assume your HTML files are under ./docs and you want the report under ./build/reports
+docs_dir="${PWD}/docs"
+reports_dir="${PWD}/build/reports"
+mkdir -p "$reports_dir"
+
+# Run the Docker image, mount the docs and a host reports directory, and set the working directory
+docker run --rm \
+  -v "${docs_dir}:${docs_dir}" \
+  -v "${reports_dir}:/reports" \
+  -w "${docs_dir}" \
+  ghcr.io/aim42/hsc:latest \
+  -r /reports
+----
+
+Add options as necessary (example)::
++
+[source,sh]
+----
+# Exclude some external links via regex and restrict checked suffixes
+docker run --rm \
+  -v "$docs_dir:$docs_dir" \
+  -v "$reports_dir:/reports" \
+  -w "$docs_dir" \
+  ghcr.io/aim42/hsc:latest \
+  -r /reports \
+  --exclude https://www.example.com/.* \
+  --suffix html,htm
+----
+
+Windows PowerShell example::
++
+[source,powershell]
+----
+$DocsDir = (Resolve-Path ./docs).Path
+$ReportsDir = (Resolve-Path ./build/reports).Path
+New-Item -Force -ItemType Directory $ReportsDir | Out-Null
+
+docker run --rm `
+  -v "$DocsDir`:$DocsDir" `
+  -v "$ReportsDir`:/reports" `
+  -w "$DocsDir" `
+  ghcr.io/aim42/hsc:latest `
+  -r /reports
+----
+
+Notes::
+
+* The container entrypoint simply invokes the CLI (`java -jar /hsc.jar`) and forwards all arguments, so you can pass the same options as described below.
+* Reports will be written to the directory you mount at `/reports` when using `-r /reports`.
+* Tags: use `:latest` for the latest released image.
+Development builds may also be available using branch-name tags (used in integration tests).
+* The integration test `integration-test/build.gradle` contains a full working example of the Docker invocation used in CI.
 
 === Options
 

--- a/htmlSanityCheck-cli/build.gradle
+++ b/htmlSanityCheck-cli/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'application'
+    id 'com.github.johnrengelman.shadow' version '8.1.1'
 }
 
 dependencies {
@@ -22,6 +23,12 @@ compileGroovy {
 application {
     mainClass = 'org.aim42.htmlsanitycheck.cli.HscCommand'
     applicationName = 'hsc'
+}
+
+shadowJar {
+    archiveClassifier.set('all')
+    mergeServiceFiles()
+    append 'META-INF/services'
 }
 
 /*

--- a/htmlSanityCheck-cli/build.gradle
+++ b/htmlSanityCheck-cli/build.gradle
@@ -1,6 +1,8 @@
 plugins {
     id 'application'
     id 'com.github.johnrengelman.shadow' version '8.1.1'
+    id 'com.fussionlabs.gradle.docker-plugin' version '0.6.0'
+
 }
 
 dependencies {
@@ -29,6 +31,29 @@ shadowJar {
     archiveClassifier.set('all')
     mergeServiceFiles()
     append 'META-INF/services'
+}
+
+def dockerTags(Project project) {
+    String currentBranch = "${'git branch --show-current'.execute().text.trim()}"
+    def result = [
+            "${currentBranch == 'main' ? 'latest' : java.time.LocalDateTime.now().format(java.time.format.DateTimeFormatter.ofPattern('yyyyMMddHHmmss'))}" as String,
+            "${currentBranch.replaceAll('/', '-')}" as String,
+            ]
+    if (currentBranch == 'main') {
+        // On the main branch we should have the latest major prepended with 'v' for GH actions
+        result += [ 'v' + project.version.substring(0, 1) ]
+    }
+
+    return result
+}
+
+docker {
+    registry = "ghcr.io"
+    repository = "aim42/hsc"
+    platforms = ["linux/amd64", "linux/arm64"]
+    buildArgs = [VERSION: project.version]
+    dockerFilePath = "."
+    tags = dockerTags(project)
 }
 
 /*

--- a/htmlSanityCheck-cli/build.gradle
+++ b/htmlSanityCheck-cli/build.gradle
@@ -56,13 +56,6 @@ docker {
     applyLatestTag = false
 }
 
-tasks.register('dockerBuildLocal', com.fussionlabs.gradle.docker.tasks.DockerBuildx) {
-    loadImage = true
-    pushImage = false
-
-    dependsOn shadowJar
-}
-
 /*
  * Copyright Gerd Aschemann and aim42 contributors.
  *

--- a/htmlSanityCheck-cli/build.gradle
+++ b/htmlSanityCheck-cli/build.gradle
@@ -49,7 +49,6 @@ def dockerTags(Project project) {
 docker {
     registry = "ghcr.io"
     repository = "aim42/hsc"
-    platforms = ["linux/amd64", "linux/arm64"]
     buildArgs = [VERSION: project.version]
     dockerFilePath = "."
     tags = dockerTags(project)
@@ -60,8 +59,24 @@ tasks.register('dockerBuildLocal', com.fussionlabs.gradle.docker.tasks.DockerBui
     loadImage = true
     pushImage = false
 
+    def arch = System.getProperty("os.arch")
+    project.extensions.getByType(com.fussionlabs.gradle.docker.DockerPluginExtension).platforms = ["linux/${(arch == 'amd64') ? 'amd64' : 'arm64'}"]
+    logger.quiet("Using Docker platform(s): ${project.extensions.getByType(com.fussionlabs.gradle.docker.DockerPluginExtension).platforms} (for arch '${arch}')")
+
     dependsOn shadowJar
 }
+
+tasks.register('dockerBuildMulti', com.fussionlabs.gradle.docker.tasks.DockerBuildx) {
+    loadImage = false
+    pushImage = true
+
+    project.extensions.getByType(com.fussionlabs.gradle.docker.DockerPluginExtension).platforms = ["linux/amd64", "linux/arm64"]
+    logger.quiet("Using Docker platform(s): ${project.extensions.getByType(com.fussionlabs.gradle.docker.DockerPluginExtension).platforms}")
+
+    dependsOn shadowJar
+}
+
+dockerPush.dependsOn("dockerBuildMulti")
 
 /*
  * Copyright Gerd Aschemann and aim42 contributors.

--- a/htmlSanityCheck-cli/build.gradle
+++ b/htmlSanityCheck-cli/build.gradle
@@ -43,13 +43,19 @@ def dockerTags(Project project) {
         result += ['v' + project.version.substring(0, 1), 'latest']
     }
 
+    def additionalTags = System.getProperty('docker.image.additional.tags')
+    if (additionalTags) {
+        logger.quiet("Adding additional tags '${additionalTags}'")
+        result += additionalTags.split(',').collect { it.trim() }
+    }
+
     return result
 }
 
 docker {
     registry = "ghcr.io"
     repository = "aim42/hsc"
-    buildArgs = [VERSION: project.version]
+    buildArgs = ["VERSION": "${project.version}" as String]
     dockerFilePath = "."
     tags = dockerTags(project)
     applyLatestTag = false

--- a/htmlSanityCheck-cli/build.gradle
+++ b/htmlSanityCheck-cli/build.gradle
@@ -34,10 +34,20 @@ shadowJar {
 
 def dockerTags(Project project) {
     String currentBranch = "${'git branch --show-current'.execute().text.trim()}"
-    def result = [
-            java.time.LocalDateTime.now().format(java.time.format.DateTimeFormatter.ofPattern('yyyyMMddHHmmss')) as String,
-            "${currentBranch.replaceAll('/', '-')}" as String,
-            ]
+    // Determine a safe tag: prefer branch name, fallback to Git SHA (from env or git)
+    String githubSha = System.getenv('GITHUB_SHA') ?: "${'git rev-parse HEAD'.execute().text.trim()}"
+    String branchOrShaTag = currentBranch ? currentBranch.replaceAll('/', '-') : (githubSha ? "${githubSha}" : null)
+
+    def result = [] as List<String>
+    // Always include a timestamp tag for traceability
+    result += java.time.LocalDateTime.now().format(java.time.format.DateTimeFormatter.ofPattern('yyyyMMddHHmmss')) as String
+    // Include branch or SHA-derived tag if available
+    if (branchOrShaTag) {
+        result += branchOrShaTag as String
+    } else {
+        logger.quiet("No branch name or Git SHA could be determined; only timestamp tag will be used")
+    }
+
     if (currentBranch == 'main') {
         // On the main branch we should have the latest major prepended with 'v' for GH actions
         result += ['v' + project.version.substring(0, 1), 'latest']
@@ -49,7 +59,8 @@ def dockerTags(Project project) {
         result += additionalTags.split(',').collect { it.trim() }
     }
 
-    return result
+    // Avoid duplicate tags (e.g., if additionalTags repeats a SHA)
+    return result.findAll { it && it.trim() }.unique()
 }
 
 docker {
@@ -62,7 +73,9 @@ docker {
 }
 
 tasks.register('dockerBuildLocal', com.fussionlabs.gradle.docker.tasks.DockerBuildx) {
-    def tag = "${'git branch --show-current'.execute().text.trim().replaceAll('/', '-')}"
+    def branch = "${'git branch --show-current'.execute().text.trim()}"
+    def sha = System.getenv('GITHUB_SHA') ?: "${'git rev-parse HEAD'.execute().text.trim()}"
+    def tag = branch ? branch.replaceAll('/', '-') : (sha ?: 'timestamp-only')
     logger.quiet("Using tag '${tag}' for dockerBuildLocal")
     loadImage = true
     pushImage = false

--- a/htmlSanityCheck-cli/build.gradle
+++ b/htmlSanityCheck-cli/build.gradle
@@ -56,6 +56,13 @@ docker {
     applyLatestTag = false
 }
 
+tasks.register('dockerBuildLocal', com.fussionlabs.gradle.docker.tasks.DockerBuildx) {
+    loadImage = true
+    pushImage = false
+
+    dependsOn shadowJar
+}
+
 /*
  * Copyright Gerd Aschemann and aim42 contributors.
  *

--- a/htmlSanityCheck-cli/build.gradle
+++ b/htmlSanityCheck-cli/build.gradle
@@ -2,7 +2,6 @@ plugins {
     id 'application'
     id 'com.github.johnrengelman.shadow' version '8.1.1'
     id 'com.fussionlabs.gradle.docker-plugin' version '0.6.0'
-
 }
 
 dependencies {
@@ -36,12 +35,12 @@ shadowJar {
 def dockerTags(Project project) {
     String currentBranch = "${'git branch --show-current'.execute().text.trim()}"
     def result = [
-            "${currentBranch == 'main' ? 'latest' : java.time.LocalDateTime.now().format(java.time.format.DateTimeFormatter.ofPattern('yyyyMMddHHmmss'))}" as String,
+            java.time.LocalDateTime.now().format(java.time.format.DateTimeFormatter.ofPattern('yyyyMMddHHmmss')) as String,
             "${currentBranch.replaceAll('/', '-')}" as String,
             ]
     if (currentBranch == 'main') {
         // On the main branch we should have the latest major prepended with 'v' for GH actions
-        result += [ 'v' + project.version.substring(0, 1) ]
+        result += ['v' + project.version.substring(0, 1), 'latest']
     }
 
     return result
@@ -54,6 +53,7 @@ docker {
     buildArgs = [VERSION: project.version]
     dockerFilePath = "."
     tags = dockerTags(project)
+    applyLatestTag = false
 }
 
 /*

--- a/htmlSanityCheck-cli/build.gradle
+++ b/htmlSanityCheck-cli/build.gradle
@@ -62,6 +62,8 @@ docker {
 }
 
 tasks.register('dockerBuildLocal', com.fussionlabs.gradle.docker.tasks.DockerBuildx) {
+    def tag = "${'git branch --show-current'.execute().text.trim().replaceAll('/', '-')}"
+    logger.quiet("Using tag '${tag}' for dockerBuildLocal")
     loadImage = true
     pushImage = false
 

--- a/htmlSanityCheck-cli/hsc.sh
+++ b/htmlSanityCheck-cli/hsc.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -euo pipefail
+
+# shellcheck disable=SC2068
+exec java -jar /hsc.jar ${*}

--- a/htmlSanityCheck-cli/src/main/groovy/org/aim42/htmlsanitycheck/cli/HscCommand.groovy
+++ b/htmlSanityCheck-cli/src/main/groovy/org/aim42/htmlsanitycheck/cli/HscCommand.groovy
@@ -92,6 +92,9 @@ class HscCommand implements Runnable {
     @Option(names = ["-e", "--exclude"], description = "Exclude remote patterns to check", split = ',')
     Pattern[] excludes = []
 
+    @Option(names = ["-f", "--fail-on-errors"], description = "Fail On Error(s)")
+    boolean failOnErrors
+
     @Parameters(index = "0", arity = "0..1", description = "base directory (default: current directory)")
     File srcDir = new File(".").getAbsoluteFile()
 
@@ -177,6 +180,7 @@ class HscCommand implements Runnable {
                     .checkingResultsDir(resultsDirectory)
                     .checksToExecute(AllCheckers.CHECKER_CLASSES)
                     .excludes(hscCommand.excludes as Set)
+                    .failOnErrors(hscCommand.failOnErrors)
                     .build()
 
             // if we have no valid configuration, abort with exception

--- a/htmlSanityCheck-gradle-plugin/README.adoc
+++ b/htmlSanityCheck-gradle-plugin/README.adoc
@@ -328,7 +328,7 @@ htmlSanityCheck {
     checkerClasses = [DuplicateIdChecker, MissingImageFilesChecker]
 
     // Exclude from checking
-    excludes = ["(http|https)://exclude.this/url.*", ".*skip-host.org.*", "https://www.baeldung.com/.*"] // <1>
+    excludes = ["(http|https)://exclude\\.this/url.*", ".*skip-host\\.org.*", "https://www\\.baeldung\\.com/.*"] // <1>
 }
 ----
 

--- a/integration-test/build.gradle
+++ b/integration-test/build.gradle
@@ -206,8 +206,6 @@ tasks.register("integrationTestDocker") {
         try {
             if (System.getProperty("os.name") ==~ /Windows.*/) {
                 'cmd /c "docker --version"'.execute().waitFor()
-                logger.quiet("Though Docker is available we currently skip Docker integration tests as there is no Windows image of HSC provided")
-                return
             } else {
                 'docker --version'.execute().waitFor()
             }

--- a/integration-test/build.gradle
+++ b/integration-test/build.gradle
@@ -206,6 +206,8 @@ tasks.register("integrationTestDocker") {
         try {
             if (System.getProperty("os.name") ==~ /Windows.*/) {
                 'cmd /c "docker --version"'.execute().waitFor()
+                logger.quiet("Though Docker is available we currently skip Docker integration tests as there is no Windows image of HSC provided")
+                return
             } else {
                 'docker --version'.execute().waitFor()
             }

--- a/integration-test/build.gradle
+++ b/integration-test/build.gradle
@@ -244,7 +244,7 @@ tasks.register("integrationTest") {
     group("Verification")
     description("Run all integration tests (without any installations etc.)")
 
-    dependsOn(integrationTestGradlePlugin, integrationTestCli, integrationTestMavenPlugin)
+    dependsOn(integrationTestGradlePlugin, integrationTestCli, integrationTestMavenPlugin, integrationTestDocker)
 }
 
 tasks.register("cleanIntegrationTest", Delete) {
@@ -252,6 +252,6 @@ tasks.register("cleanIntegrationTest", Delete) {
     description("Deletes all integration test builds")
 
     dependsOn(cleanIntegrationTestCommon, cleanIntegrationTestGradlePlugin,
-            cleanIntegrationTestCli, cleanIntegrationTestMavenPlugin)
+            cleanIntegrationTestCli, cleanIntegrationTestMavenPlugin, cleanIntegrationTestDocker)
 }
 clean.dependsOn(cleanIntegrationTest)

--- a/integration-test/build.gradle
+++ b/integration-test/build.gradle
@@ -219,14 +219,17 @@ tasks.register("integrationTestDocker") {
         buildReportsDirectory.mkdirs()
         // Compute the image tag exactly as in the CLI module: use branch name tag
         String currentBranch = "${'git branch --show-current'.execute().text.trim()}"
-        String branchTag = currentBranch.replaceAll('/', '-')
-        String image = "ghcr.io/aim42/hsc:${branchTag}"
+        String branchTag = currentBranch?.replaceAll('/', '-')
+        String sha = System.getenv('GITHUB_SHA') ?: "${'git rev-parse HEAD'.execute().text.trim()}"
+        String tag = branchTag ?: sha
+        String image = "ghcr.io/aim42/hsc:${tag}"
 
         // Prepare absolute paths for volume mounts
         String docsDir = file("${INTEGRATION_TEST_DIRECTORY_COMMON_BUILD}/docs").absolutePath
         String reportsDir = buildReportsDirectory.absolutePath
 
         String params = "--rm -v \"${docsDir}:${docsDir}\" -v \"${reportsDir}\":/reports -w \"${docsDir}\" ${image} -r /reports --exclude https://www\\.baeldung\\.com/.* --fail-on-errors"
+        logger.quiet("Executing Docker run with '${params}'")
         def result = exec {
             if (System.getProperty("os.name") ==~ /Windows.*/) {
                 // Use cmd to run docker on Windows

--- a/integration-test/build.gradle
+++ b/integration-test/build.gradle
@@ -115,7 +115,7 @@ tasks.register("integrationTestCli") {
             buildReportsDirectory.mkdirs()
             final String hscScriptFileName = "../htmlSanityCheck-cli/${BUILD_DIRECTORY}/install/hsc/bin/hsc"
             String params = "-r ${buildReportsDirectory} " +
-                    "--exclude https://www.baeldung.com/.*" +
+                    "--exclude https://www\\.baeldung\\.com/.*" +
                     "${INTEGRATION_TEST_DIRECTORY_COMMON_BUILD}/docs"
             if (System.getProperty("os.name") ==~ /Windows.*/) {
                 commandLine 'cmd', '/c', "echo off && ${hscScriptFileName.replace('/', '\\')}.bat ${params}"
@@ -175,6 +175,67 @@ tasks.register("integrationTestMavenPlugin") {
             }
         }
         logger.debug "Script output: $result"
+        assert testIndex.exists()
+    }
+}
+
+final String INTEGRATION_TEST_DIRECTORY_DOCKER = "docker"
+final String INTEGRATION_TEST_DIRECTORY_DOCKER_BUILD = "${INTEGRATION_TEST_DIRECTORY_DOCKER}/${BUILD_DIRECTORY}"
+
+tasks.register("cleanIntegrationTestDocker", Delete) {
+    group("Build")
+    description("Deletes the result directory from Docker integration tests")
+
+    def filesToDelete = files(INTEGRATION_TEST_DIRECTORY_DOCKER_BUILD)
+    delete(filesToDelete)
+    outputs.upToDateWhen { !filesToDelete.files.any { it.exists() } }
+}
+
+tasks.register("integrationTestDocker") {
+    group("Verification")
+    description("Run Docker integration tests (only)")
+
+    final File buildReportsDirectory = file("${INTEGRATION_TEST_DIRECTORY_DOCKER_BUILD}/reports")
+    final File testIndex = new File(buildReportsDirectory, "index.html")
+    outputs.file testIndex
+
+    dependsOn(integrationTestPrepare)
+    mustRunAfter(cleanIntegrationTestDocker)
+
+    doLast {
+        try {
+            if (System.getProperty("os.name") ==~ /Windows.*/) {
+                'cmd /c "docker --version"'.execute().waitFor()
+                logger.quiet("Though Docker is available we currently skip Docker integration tests as there is no Windows image of HSC provided")
+                return
+            } else {
+                'docker --version'.execute().waitFor()
+            }
+        } catch (Exception e) {
+            logger.quiet("Docker is not available - skipping Docker integration tests", e)
+            return
+        }
+
+        buildReportsDirectory.mkdirs()
+        // Compute the image tag exactly as in the CLI module: use branch name tag
+        String currentBranch = "${'git branch --show-current'.execute().text.trim()}"
+        String branchTag = currentBranch.replaceAll('/', '-')
+        String image = "ghcr.io/aim42/hsc:${branchTag}"
+
+        // Prepare absolute paths for volume mounts
+        String docsDir = file("${INTEGRATION_TEST_DIRECTORY_COMMON_BUILD}/docs").absolutePath
+        String reportsDir = buildReportsDirectory.absolutePath
+
+        String params = "--rm -v \"${docsDir}:${docsDir}\" -v \"${reportsDir}\":/reports -w \"${docsDir}\" ${image} -r /reports --exclude https://www\\.baeldung\\.com/.*"
+        def result = exec {
+            if (System.getProperty("os.name") ==~ /Windows.*/) {
+                // Use cmd to run docker on Windows
+                commandLine 'cmd', '/c', "docker run ${params}"
+            } else {
+                commandLine 'sh', '-c', "docker run ${params}"
+            }
+        }
+        logger.debug "Script output: ${result}"
         assert testIndex.exists()
     }
 }

--- a/integration-test/build.gradle
+++ b/integration-test/build.gradle
@@ -226,7 +226,7 @@ tasks.register("integrationTestDocker") {
         String docsDir = file("${INTEGRATION_TEST_DIRECTORY_COMMON_BUILD}/docs").absolutePath
         String reportsDir = buildReportsDirectory.absolutePath
 
-        String params = "--rm -v \"${docsDir}:${docsDir}\" -v \"${reportsDir}\":/reports -w \"${docsDir}\" ${image} -r /reports --exclude https://www\\.baeldung\\.com/.*"
+        String params = "--rm -v \"${docsDir}:${docsDir}\" -v \"${reportsDir}\":/reports -w \"${docsDir}\" ${image} -r /reports --exclude https://www\\.baeldung\\.com/.* --fail-on-errors"
         def result = exec {
             if (System.getProperty("os.name") ==~ /Windows.*/) {
                 // Use cmd to run docker on Windows

--- a/integration-test/gradle-plugin/build.gradle
+++ b/integration-test/gradle-plugin/build.gradle
@@ -10,7 +10,7 @@ File reports = file("${Project.DEFAULT_BUILD_DIR_NAME}/reports")
 htmlSanityCheck {
     sourceDir = file("../common/${Project.DEFAULT_BUILD_DIR_NAME}/docs")
 
-    excludes = ["https://www.baeldung.com/.*"]
+    excludes = ["https://www\\.baeldung\\.com/.*"]
 
     httpSuccessCodes = [429]
 

--- a/integration-test/maven-plugin/pom.xml
+++ b/integration-test/maven-plugin/pom.xml
@@ -33,7 +33,7 @@
                         <file>../common/build/docs/README.html</file>
                     </sourceDocuments>
                     <excludes>
-                        <exclude>https://www.baeldung.com/.*</exclude>
+                        <exclude>https://www\.baeldung\.com/.*</exclude>
                     </excludes>
                     <sourceDir>../common/build/docs</sourceDir>
                     <checkingResultsDir>${project.build.directory}/reports</checkingResultsDir>

--- a/self-check/build.gradle
+++ b/self-check/build.gradle
@@ -7,7 +7,7 @@ htmlSanityCheck {
 
     checkingResultsDir = file("../build/reports/htmlchecks")
     excludes = [
-            "https://www.baeldung.com/.*", // Baeldung seems to have implemented some anti-robot/GPT strategy?
+            "https://www\\.baeldung\\.com/.*", // Baeldung seems to have implemented some anti-robot/GPT strategy?
             "https://www.iconfinder.com/icons/118743/arrow_up_icon", "https://www.freepik.com/", // Both fail frequently on GitHub pages
     ]
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,6 +2,7 @@ pluginManagement {
     repositories {
         gradlePluginPortal()
         mavenCentral()
+        mavenLocal()
     }
 }
 


### PR DESCRIPTION
### Summary
This PR adds a first‑class, Docker‑based GitHub Action for HTML Sanity Check (HSC) and a reusable container image published to GHCR. It also introduces CI jobs to build, test, and publish multi‑arch Docker images and a scheduled workflow that cleans up old, timestamped image versions from GHCR.

### What’s included
- New GitHub Action backed by Docker image
  - `action.yml` runs using `docker://ghcr.io/aim42/hsc:v2` with entrypoint `'/hsc.sh'`.
  - Single input `args` to pass through to the CLI (`HscCommand`).
- Reusable Docker image for independent, container‑based execution of HSC
  - Dockerfile based on `eclipse-temurin:21-jre-alpine`.
  - Copies shaded CLI JAR and lightweight `hsc.sh` entrypoint.
  - Multi‑arch builds (`linux/amd64`, `linux/arm64`).
- CI workflow for build, test, and publish
  - `.github/workflows/gradle-build.yml` now:
    - Builds artifacts and runs existing tests.
    - Pulls the branch‑tagged image, re‑tags as `v2`, and executes the new Action end‑to‑end as part of CI.
    - Publishes Docker images to GHCR via Gradle’s Docker plugin, with optional extra tags via `workflow_dispatch` input `additional_tags`.
- GHCR cleanup workflow
  - `.github/workflows/cleanup-ghcr.yml` removes old timestamped or stale SHA‑only image versions (default retention 14 days), while protecting `latest` and `v*` tags.

### Implementation Details
- `action.yml`
  - `runs.using: 'docker'` with fixed image `ghcr.io/aim42/hsc:v2` and `entrypoint: '/hsc.sh'`.
  - Note: If the action’s image tag changes (e.g., to `v3`), the test in `gradle-build.yml` must be updated accordingly (inline comment present).
- `htmlSanityCheck-cli/Dockerfile`
  - Labels include `org.opencontainers.image.description` and `version` (ARG‑driven) for provenance.
  - Uses `hsc.sh` to exec `java -jar /hsc.jar` with passed arguments.
- `htmlSanityCheck-cli/build.gradle`
  - Uses `com.fussionlabs.gradle.docker-plugin` for Buildx.
  - Tagging strategy (`dockerTags`):
    - Always: timestamp `yyyyMMddHHmmss` and sanitized branch name.
    - On `main`: also push `v<major>` (for the Action) and `latest`.
    - Supports additional tags via `-Ddocker.image.additional.tags`.
  - Multi‑arch push wired via `dockerBuildMulti`; `dockerPush` depends on it.
- `.github/workflows/gradle-build.yml`
  - `test-gh-action` pulls the branch image, tags it locally as `ghcr.io/aim42/hsc:v2`, and runs the Action from this repo with sample args to validate end‑to‑end behavior.
  - `publish-docker-images` uses the Gradle task `dockerPush` with Buildx multi‑arch and GitHub Packages auth via `GITHUB_TOKEN`.
- `.github/workflows/cleanup-ghcr.yml`
  - Nightly (02:00 UTC) or manual.
  - Deletes versions older than retention days when:
    - Any timestamp tag (`yyyyMMddHHmmss`) is older than cutoff, or
    - Only SHA‑like tags exist and version `created_at/updated_at` is older than cutoff, or
    - No tags at all and older than cutoff.
  - Skips versions that contain `latest` or `v\d+` tags.
  - Defaults to dry‑run on manual dispatch; can be overridden.

### Usage
- In GitHub Actions (recommended)
  ```yaml
  - name: HTML Sanity Check
    uses: aim42/htmlSanityCheck@<ref>
    with:
      args: >-
        -r build/gh-action-test-report integration-test/common/build/docs \
        --exclude 'https://www\.baeldung\.com/.*' \
        --fail-on-errors
  ```
  - Replace `<ref>` with a tag, branch, or commit SHA of this repository.
  - The Action will run the Docker image `ghcr.io/aim42/hsc:v2` under the hood.

- As a standalone Docker image
  ```bash
  docker run --rm \
    -v "$PWD:/work" \
    -w /work \
    ghcr.io/aim42/hsc:v2 \
    -r build/hsc-report path/to/site \
    --fail-on-errors
  ```

### Why this change
- Provides a simple, consistent way to run HSC in CI without managing JDKs or local installs.
- Enables reproducible, containerized execution for local use and other CI systems.
- Keeps GHCR tidy by removing ephemeral, timestamped images after a retention period, saving storage and reducing clutter.

### Backward compatibility
- No breaking changes to the core CLI.
- GitHub Action is new; consumers can adopt it incrementally.

### Security and Permissions
- Docker images are published to GHCR using `GITHUB_TOKEN` with `packages: write`.
- Cleanup workflow only runs on schedule for `main` (or via manual dispatch) and skips protected tags (`latest`, `v*`).

### Testing
- CI job `test-gh-action` validates the Action end‑to‑end using a locally retagged image matching `v2`.
- Artifacts and a simple report are uploaded for inspection.

### Follow‑ups
- When releasing a new major, bump the Action image tag (e.g., `v3`) in `action.yml` and the test workflow.
- Optionally document the full CLI options in the project docs and link them from `action.yml`.

### Issues
- Contributes to #343 
- Closes #369
